### PR TITLE
Fix passing arguments with spaces to external commands

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -204,6 +204,14 @@ version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
+name = "lazy-string-replace"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "memchr 2.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "lazy_static"
 version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -364,6 +372,7 @@ dependencies = [
  "derive_builder 0.7.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "env_logger 0.6.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "fuzzy-matcher 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "lazy-string-replace 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "lazy_static 1.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "nix 0.14.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -570,6 +579,7 @@ dependencies = [
 "checksum fuzzy-matcher 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)" = "2db8c952765d7250f5fa509db7f6510ceef4be8672affc9bdbeffa2695923f67"
 "checksum humantime 1.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "3ca7e5f2e110db35f93b837c81797f3714500b81d517bf20c431b16d3ca4f114"
 "checksum ident_case 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)" = "b9e0384b61958566e926dc50660321d12159025e767c18e043daf26b70104c39"
+"checksum lazy-string-replace 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "6231f5b927e19646db5ca9173f2c79accd45a1d43213bfb2d41cb0007af17104"
 "checksum lazy_static 1.3.0 (registry+https://github.com/rust-lang/crates.io-index)" = "bc5729f27f159ddd61f4df6228e827e86643d4d3e7c32183cb30a1c08f604a14"
 "checksum libc 0.2.58 (registry+https://github.com/rust-lang/crates.io-index)" = "6281b86796ba5e4366000be6e9e18bf35580adf9e63fbe2294aadb587613a319"
 "checksum log 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)" = "c84ec4b527950aa83a329754b01dbe3f58361d1c5efacd1f6d68c494d08a17c6"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -38,6 +38,7 @@ derive_builder = "0.7.1"
 bitflags = "1.0.4"
 timer = "0.2.0"
 chrono = "0.4"
+lazy-string-replace = "0.1.1"
 
 [features]
 default = []

--- a/src/query.rs
+++ b/src/query.rs
@@ -116,12 +116,7 @@ impl Query {
     }
 
     pub fn get_cmd(&self) -> String {
-        let arg: String = self
-            .cmd_before
-            .iter()
-            .cloned()
-            .chain(self.cmd_after.iter().cloned().rev())
-            .collect();
+        let arg = self.get_cmd_query();
 
         let out = if arg.is_empty() {
             self.base_cmd.replace(&self.replstr[..], "")

--- a/src/query.rs
+++ b/src/query.rs
@@ -123,11 +123,15 @@ impl Query {
             .chain(self.cmd_after.iter().cloned().rev())
             .collect();
 
-        let out = format!(
-            "{}",
-            self.base_cmd
-                .lazy_replace(&self.replstr[..], format_args!("'{}'", escape_single_quote(&arg)))
-        );
+        let out = if arg.is_empty() {
+            self.base_cmd.replace(&self.replstr[..], "")
+        } else {
+            format!(
+                "{}",
+                self.base_cmd
+                    .lazy_replace(&self.replstr[..], format_args!("'{}'", escape_single_quote(&arg)))
+            )
+        };
         out
     }
 

--- a/src/query.rs
+++ b/src/query.rs
@@ -126,11 +126,9 @@ impl Query {
         let out = if arg.is_empty() {
             self.base_cmd.replace(&self.replstr[..], "")
         } else {
-            format!(
-                "{}",
-                self.base_cmd
-                    .lazy_replace(&self.replstr[..], format_args!("'{}'", escape_single_quote(&arg)))
-            )
+            self.base_cmd
+                .lazy_replace(&self.replstr[..], format_args!("'{}'", escape_single_quote(&arg)))
+                .to_string()
         };
         out
     }

--- a/src/query.rs
+++ b/src/query.rs
@@ -1,6 +1,8 @@
 use crate::event::{Event, EventArg, EventHandler, UpdateScreen};
 use crate::options::SkimOptions;
 use crate::theme::{ColorTheme, DEFAULT_THEME};
+use crate::util::escape_single_quote;
+use lazy_string_replace::LazyReplace;
 use std::mem;
 use std::sync::Arc;
 use tuikit::prelude::*;
@@ -120,7 +122,13 @@ impl Query {
             .cloned()
             .chain(self.cmd_after.iter().cloned().rev())
             .collect();
-        self.base_cmd.replace(&self.replstr, &arg)
+
+        let out = format!(
+            "{}",
+            self.base_cmd
+                .lazy_replace(&self.replstr[..], format_args!("'{}'", escape_single_quote(&arg)))
+        );
+        out
     }
 
     pub fn get_cmd_query(&self) -> String {

--- a/src/util.rs
+++ b/src/util.rs
@@ -2,6 +2,7 @@ use crate::field::get_string_by_range;
 use regex::{Captures, Regex};
 use std::borrow::Cow;
 use std::cmp::min;
+use std::fmt::Display;
 use std::prelude::v1::*;
 use tuikit::prelude::*;
 use unicode_width::UnicodeWidthChar;
@@ -10,8 +11,8 @@ lazy_static! {
     static ref RE_FIELDS: Regex = Regex::new(r"\\?(\{ *-?[0-9.,cq+]*? *})").unwrap();
 }
 
-pub fn escape_single_quote(text: &str) -> String {
-    text.replace("'", "'\\''")
+pub fn escape_single_quote<'a>(text: &'a str) -> impl Display + 'a {
+    lazy_string_replace::ReplacedString::new(text, '\'', "'\\''")
 }
 
 /// use to print a single line, properly handle the tabsteop and shift of a string

--- a/src/util.rs
+++ b/src/util.rs
@@ -1,4 +1,5 @@
 use crate::field::get_string_by_range;
+use lazy_string_replace::LazyReplace;
 use regex::{Captures, Regex};
 use std::borrow::Cow;
 use std::cmp::min;
@@ -12,7 +13,7 @@ lazy_static! {
 }
 
 pub fn escape_single_quote<'a>(text: &'a str) -> impl Display + 'a {
-    lazy_string_replace::ReplacedString::new(text, '\'', "'\\''")
+    text.lazy_replace('\'', "'\\''")
 }
 
 /// use to print a single line, properly handle the tabsteop and shift of a string

--- a/src/util.rs
+++ b/src/util.rs
@@ -12,7 +12,7 @@ lazy_static! {
     static ref RE_FIELDS: Regex = Regex::new(r"\\?(\{ *-?[0-9.,cq+]*? *})").unwrap();
 }
 
-pub fn escape_single_quote<'a>(text: &'a str) -> impl Display + 'a {
+pub fn escape_single_quote(text: &str) -> impl Display + '_ {
     text.lazy_replace('\'', "'\\''")
 }
 


### PR DESCRIPTION
Surrounds the parameter passed to the `-c`/`--command` external executable with `'..'` and escapes the string appropriately. This means that when doing interactive grep using ripgrep you can type `pub fn my_function_name` - a very commonly-needed query - and get the correct result.

I assume this wasn't previously done for performance reason, so PR uses my lazy string replacement crate to avoid intermediate allocations. The speed should be pretty good despite escaping, surrounding with quotes and then replacing the `{}` (or other `-I` string) in the command parameter since that's all done in one pass.

From testing on my own computer the speed is very good, but that's just anecdotal evidence.