### PR TITLE
Add score to the tiebreak on ^R keybindings

### DIFF
--- a/shell/key-bindings.bash
+++ b/shell/key-bindings.bash
@@ -50,7 +50,7 @@ __skim_history__() {
   output=$(
     builtin fc -lnr -2147483648 |
       last_hist=$(HISTTIMEFORMAT='' builtin history 1) perl -n -l0 -e 'BEGIN { getc; $/ = "\n\t"; $HISTCMD = $ENV{last_hist} + 1 } s/^[ *]//; print $HISTCMD - $. . "\t$_" if !$seen{$_}++' |
-      SKIM_DEFAULT_OPTIONS="--height ${SKIM_TMUX_HEIGHT:-40%} $SKIM_DEFAULT_OPTIONS -n2..,.. --tiebreak=index --bind=ctrl-r:toggle-sort $SKIM_CTRL_R_OPTS --no-multi --read0" $(__skimcmd) --query "$READLINE_LINE"
+      SKIM_DEFAULT_OPTIONS="--height ${SKIM_TMUX_HEIGHT:-40%} $SKIM_DEFAULT_OPTIONS -n2..,.. --tiebreak=score,index --bind=ctrl-r:toggle-sort $SKIM_CTRL_R_OPTS --no-multi --read0" $(__skimcmd) --query "$READLINE_LINE"
   ) || return
   READLINE_LINE=${output#*$'\t'}
   if [ -z "$READLINE_POINT" ]; then

--- a/shell/key-bindings.fish
+++ b/shell/key-bindings.fish
@@ -54,7 +54,7 @@ function skim_key_bindings
   function skim-history-widget -d "Show command history"
     test -n "$SKIM_TMUX_HEIGHT"; or set SKIM_TMUX_HEIGHT 40%
     begin
-      set -lx SKIM_DEFAULT_OPTIONS "--height $SKIM_TMUX_HEIGHT $SKIM_DEFAULT_OPTIONS --tiebreak=index --bind=ctrl-r:toggle-sort $SKIM_CTRL_R_OPTS --no-multi"
+      set -lx SKIM_DEFAULT_OPTIONS "--height $SKIM_TMUX_HEIGHT $SKIM_DEFAULT_OPTIONS --tiebreak=score,index --bind=ctrl-r:toggle-sort $SKIM_CTRL_R_OPTS --no-multi"
 
       set -l FISH_MAJOR (echo $version | cut -f1 -d.)
       set -l FISH_MINOR (echo $version | cut -f2 -d.)

--- a/shell/key-bindings.zsh
+++ b/shell/key-bindings.zsh
@@ -119,7 +119,7 @@ skim-history-widget() {
   local selected num
   setopt localoptions noglobsubst noposixbuiltins pipefail no_aliases 2> /dev/null
   selected=( $(fc -rl 1 | perl -ne 'print if !$seen{(/^\s*[0-9]+\**\s+(.*)/, $1)}++' |
-    SKIM_DEFAULT_OPTIONS="--height ${SKIM_TMUX_HEIGHT:-40%} $SKIM_DEFAULT_OPTIONS -n2..,.. --tiebreak=index --bind=ctrl-r:toggle-sort $SKIM_CTRL_R_OPTS --query=${(qqq)LBUFFER} --no-multi" $(__skimcmd)) )
+    SKIM_DEFAULT_OPTIONS="--height ${SKIM_TMUX_HEIGHT:-40%} $SKIM_DEFAULT_OPTIONS -n2..,.. --tiebreak=score,index --bind=ctrl-r:toggle-sort $SKIM_CTRL_R_OPTS --query=${(qqq)LBUFFER} --no-multi" $(__skimcmd)) )
   local ret=$?
   if [ -n "$selected" ]; then
     num=$selected[1]


### PR DESCRIPTION
Skim's `--tiebreak=index` will match if the letters in the query appear in
the text.  E.g. searching for "hello" in the following text will match
on the long line that does not contain "hello" first.

```
$ echo "hotel echo lima lima oscar\nhello" | sk --tiebreak=index

  hello
> hotel echo lima lima oscar
  2/2
> hello
```

This differs from fzf, which will still prioritize an exact word match.

```
$ echo "hotel echo lima lima oscar\nhello" | fzf --tiebreak=index

  hotel echo lima lima oscar
> hello
  2/2
> hello
```

This breaks ^R in complex histories, where long commands may be run
which contain all the letters in the right order in the searched string,
but are completely unrelated to the user's query.  The user will have to
preface the query with ' every time in order to get a usable result.

Because of this skim needs to either prioritize whole-word matches even
when `--tiebreak=index` or the ^R bindings need to tiebreak on score
before index.  This commit chooses the latter.