### PR TITLE
feat: add preview callback

### DIFF
--- a/skim/examples/preview_callback.rs
+++ b/skim/examples/preview_callback.rs
@@ -3,11 +3,14 @@ use std::io::Cursor;
 use skim::prelude::*;
 
 pub fn main() {
+    let _ = env_logger::init();
     let options = SkimOptionsBuilder::default()
-        .height(String::from("50%"))
         .multi(true)
-        .preview_fn(Some(PreviewCallback::from(|items: Vec<String>| {
-            items.iter().map(|s| s.to_ascii_uppercase().into()).collect::<Vec<_>>()
+        .preview_fn(Some(PreviewCallback::from(|items: Vec<Arc<dyn SkimItem>>| {
+            items
+                .iter()
+                .map(|s| s.text().to_ascii_uppercase().into())
+                .collect::<Vec<_>>()
         })))
         .build()
         .unwrap();
@@ -20,6 +23,6 @@ pub fn main() {
         .unwrap_or_else(|| Vec::new());
 
     for item in selected_items.iter() {
-        print!("{}{}", item.output(), "\n");
+        println!("{}", item.output());
     }
 }

--- a/skim/examples/preview_callback.rs
+++ b/skim/examples/preview_callback.rs
@@ -1,0 +1,25 @@
+use std::io::Cursor;
+
+use skim::prelude::*;
+
+pub fn main() {
+    let options = SkimOptionsBuilder::default()
+        .height(String::from("50%"))
+        .multi(true)
+        .preview_fn(Some(PreviewCallback::from(|items: Vec<String>| {
+            items.iter().map(|s| s.to_ascii_uppercase().into()).collect::<Vec<_>>()
+        })))
+        .build()
+        .unwrap();
+    let item_reader = SkimItemReader::default();
+
+    let input = "aaaaa\nbbbb\nccc";
+    let items = item_reader.of_bufread(Cursor::new(input));
+    let selected_items = Skim::run_with(&options, Some(items))
+        .map(|out| out.selected_items)
+        .unwrap_or_else(|| Vec::new());
+
+    for item in selected_items.iter() {
+        print!("{}{}", item.output(), "\n");
+    }
+}

--- a/skim/src/lib.rs
+++ b/skim/src/lib.rs
@@ -219,7 +219,6 @@ pub struct PreviewPosition {
 pub enum ItemPreview {
     /// execute the command and print the command's output
     Command(String),
-    // Callback,
     /// Display the prepared text(lines)
     Text(String),
     /// Display the colored text(lines)

--- a/skim/src/lib.rs
+++ b/skim/src/lib.rs
@@ -219,6 +219,7 @@ pub struct PreviewPosition {
 pub enum ItemPreview {
     /// execute the command and print the command's output
     Command(String),
+    // Callback,
     /// Display the prepared text(lines)
     Text(String),
     /// Display the colored text(lines)

--- a/skim/src/options.rs
+++ b/skim/src/options.rs
@@ -7,6 +7,7 @@ use derive_builder::Builder;
 use crate::item::RankCriteria;
 use crate::model::options::InfoDisplay;
 use crate::prelude::SkimItemReader;
+use crate::previewer::PreviewCallback;
 use crate::reader::CommandCollector;
 use crate::util::read_file_lines;
 use crate::{CaseMatching, FuzzyAlgorithm, Selector};
@@ -731,6 +732,8 @@ pub struct SkimOptions {
     pub cmd_history: Vec<String>,
     #[clap(skip)]
     pub selector: Option<Rc<dyn Selector>>,
+    #[clap(skip)]
+    pub preview_fn: Option<PreviewCallback>,
 }
 
 impl Default for SkimOptions {

--- a/skim/src/options.rs
+++ b/skim/src/options.rs
@@ -732,6 +732,11 @@ pub struct SkimOptions {
     pub cmd_history: Vec<String>,
     #[clap(skip)]
     pub selector: Option<Rc<dyn Selector>>,
+    /// Preview Callback
+    ///
+    /// Used to define a function or closure for the preview window, instead of a shell command
+    /// The function will take a `Vec<Arc<dyn SkimItem>>>` containing the currently selected items
+    /// And return a Vec<String> with the lines to display in UTF-8
     #[clap(skip)]
     pub preview_fn: Option<PreviewCallback>,
 }

--- a/skim/src/prelude.rs
+++ b/skim/src/prelude.rs
@@ -5,6 +5,7 @@ pub use crate::helper::item_reader::{SkimItemReader, SkimItemReaderOption};
 pub use crate::helper::selector::DefaultSkimSelector;
 pub use crate::options::{SkimOptions, SkimOptionsBuilder};
 pub use crate::output::SkimOutput;
+pub use crate::previewer::PreviewCallback;
 pub use crate::*;
 pub use crossbeam::channel::{bounded, unbounded, Receiver, Sender};
 pub use std::borrow::Cow;

--- a/skim/src/previewer.rs
+++ b/skim/src/previewer.rs
@@ -22,6 +22,29 @@ use crate::{ItemPreview, PreviewContext, PreviewPosition, SkimItem};
 const TAB_STOP: usize = 8;
 const DELIMITER_STR: &str = r"[\t\n ]+";
 
+#[derive(Clone)]
+pub struct PreviewCallback {
+    inner: Arc<dyn Fn(Vec<String>) -> Vec<AnsiString<'static>> + Send + Sync + 'static>,
+}
+
+/// Handy conversion from Fn() to type. Used in the SkimOption builder
+impl<F> From<F> for PreviewCallback
+where
+    F: Fn(Vec<String>) -> Vec<AnsiString<'static>> + Send + Sync + 'static,
+{
+    fn from(func: F) -> Self {
+        Self { inner: Arc::new(func) }
+    }
+}
+
+impl std::ops::Deref for PreviewCallback {
+    type Target = dyn Fn(Vec<String>) -> Vec<AnsiString<'static>> + Send + Sync + 'static;
+
+    fn deref(&self) -> &Self::Target {
+        &*self.inner
+    }
+}
+
 pub struct Previewer {
     tx_preview: Sender<PreviewEvent>,
     content_lines: Arc<SpinLock<Vec<AnsiString<'static>>>>,
@@ -38,13 +61,14 @@ pub struct Previewer {
     prev_num_selected: usize,
 
     preview_cmd: Option<String>,
+    preview_cb: Option<PreviewCallback>,
     preview_offset: String, // e.g. +SCROLL-OFFSET
     delimiter: Regex,
     thread_previewer: Option<JoinHandle<()>>,
 }
 
 impl Previewer {
-    pub fn new<C>(preview_cmd: Option<String>, callback: C) -> Self
+    pub fn new_from_command<C>(preview_cmd: Option<String>, callback: C) -> Self
     where
         C: Fn() + Send + Sync + 'static,
     {
@@ -94,6 +118,64 @@ impl Previewer {
             prev_num_selected: 0,
 
             preview_cmd,
+            preview_cb: None,
+            preview_offset: "".to_string(),
+            delimiter: Regex::new(DELIMITER_STR).unwrap(),
+            thread_previewer: Some(thread_previewer),
+        }
+    }
+
+    pub fn new_with_callback<C>(user_callback: PreviewCallback, callback: C) -> Self
+    where
+        C: Fn() + Send + Sync + 'static,
+    {
+        let content_lines = Arc::new(SpinLock::new(Vec::new()));
+        let (tx_preview, rx_preview) = channel();
+        let width = Arc::new(AtomicUsize::new(80));
+        let height = Arc::new(AtomicUsize::new(60));
+        let hscroll_offset = Arc::new(AtomicUsize::new(1));
+        let vscroll_offset = Arc::new(AtomicUsize::new(1));
+
+        let content_clone = content_lines.clone();
+        let width_clone = width.clone();
+        let height_clone = height.clone();
+        let hscroll_offset_clone = hscroll_offset.clone();
+        let vscroll_offset_clone = vscroll_offset.clone();
+        let thread_previewer = thread::spawn(move || {
+            run(rx_preview, move |lines, pos| {
+                let width = width_clone.load(Ordering::SeqCst);
+                let height = height_clone.load(Ordering::SeqCst);
+
+                let hscroll = pos.h_scroll.calc_fixed_size(lines.len(), 0);
+                let hoffset = pos.h_offset.calc_fixed_size(width, 0);
+                let vscroll = pos.v_scroll.calc_fixed_size(usize::MAX, 0);
+                let voffset = pos.v_offset.calc_fixed_size(height, 0);
+
+                hscroll_offset_clone.store(max(1, max(hscroll, hoffset) - hoffset), Ordering::SeqCst);
+                vscroll_offset_clone.store(max(1, max(vscroll, voffset) - voffset), Ordering::SeqCst);
+                *content_clone.lock() = lines;
+
+                callback();
+            })
+        });
+
+        Self {
+            tx_preview,
+            content_lines,
+
+            width,
+            height,
+            hscroll_offset,
+            vscroll_offset,
+            wrap: false,
+
+            prev_item: None,
+            prev_query: None,
+            prev_cmd_query: None,
+            prev_num_selected: 0,
+
+            preview_cmd: None,
+            preview_cb: Some(user_callback),
             preview_offset: "".to_string(),
             delimiter: Regex::new(DELIMITER_STR).unwrap(),
             thread_previewer: Some(thread_previewer),
@@ -220,16 +302,24 @@ impl Previewer {
                     }
                 }
                 (ItemPreview::Global, _) => {
-                    let cmd = self.preview_cmd.clone().expect("previewer: not provided");
-                    if depends_on_items(&cmd) && self.prev_item.is_none() {
-                        debug!("the command for preview refers to items and currently there is no item");
-                        debug!("command to execute: [{}]", cmd);
-                        PreviewEvent::PreviewPlainText("no item matched".to_string(), Default::default())
-                    } else {
-                        let cmd = inject_command(&cmd, inject_context).to_string();
+                    if let Some(cmd) = self.preview_cmd.as_ref() {
+                        if depends_on_items(&cmd) && self.prev_item.is_none() {
+                            debug!("the command for preview refers to items and currently there is no item");
+                            debug!("command to execute: [{}]", cmd);
+                            PreviewEvent::PreviewPlainText("no item matched".to_string(), Default::default())
+                        } else {
+                            let cmd = inject_command(cmd, inject_context).to_string();
+                            let pos = self.eval_scroll_offset(inject_context);
+                            let preview_command = PreviewCommand { cmd, columns, lines };
+                            PreviewEvent::PreviewCommand(preview_command, pos)
+                        }
+                    } else if let Some(cb) = self.preview_cb.as_ref() {
                         let pos = self.eval_scroll_offset(inject_context);
-                        let preview_command = PreviewCommand { cmd, columns, lines };
-                        PreviewEvent::PreviewCommand(preview_command, pos)
+                        let selection: Vec<String> = selected_texts.into_iter().map(ToOwned::to_owned).collect();
+                        let cb = cb.clone();
+                        PreviewEvent::PreviewCallback(Box::new(move || cb(selection)), pos)
+                    } else {
+                        PreviewEvent::Noop
                     }
                 }
             },
@@ -403,8 +493,12 @@ pub struct PreviewCommand {
     pub columns: usize,
 }
 
-#[derive(Debug)]
+// #[derive(Debug)]
 enum PreviewEvent {
+    PreviewCallback(
+        Box<dyn FnOnce() -> Vec<AnsiString<'static>> + Send + Sync + 'static>,
+        PreviewPosition,
+    ),
     PreviewCommand(PreviewCommand, PreviewPosition),
     PreviewPlainText(String, PreviewPosition),
     PreviewAnsiText(String, PreviewPosition),
@@ -490,6 +584,7 @@ where
                     }
                 }
             }
+            PreviewEvent::PreviewCallback(cb, pos) => callback(cb(), pos),
             PreviewEvent::PreviewPlainText(text, pos) => {
                 callback(text.lines().map(|line| line.to_string().into()).collect(), pos);
             }

--- a/skim/src/previewer.rs
+++ b/skim/src/previewer.rs
@@ -28,7 +28,6 @@ pub struct PreviewCallback {
     inner: Arc<dyn Fn(Vec<Arc<dyn SkimItem>>) -> Vec<AnsiString<'static>> + Send + Sync + 'static>,
 }
 
-/// Handy conversion from Fn() to type. Used in the SkimOption builder
 impl<F> From<F> for PreviewCallback
 where
     F: Fn(Vec<Arc<dyn SkimItem>>) -> Vec<AnsiString<'static>> + Send + Sync + 'static,

--- a/skim/src/previewer.rs
+++ b/skim/src/previewer.rs
@@ -60,15 +60,22 @@ pub struct Previewer {
     prev_cmd_query: Option<String>,
     prev_num_selected: usize,
 
-    preview_cmd: Option<String>,
-    preview_cb: Option<PreviewCallback>,
+    preview_source: PreviewSource,
     preview_offset: String, // e.g. +SCROLL-OFFSET
     delimiter: Regex,
     thread_previewer: Option<JoinHandle<()>>,
 }
 
+/// Source for the Preview window.
+#[non_exhaustive]
+pub enum PreviewSource {
+    Empty,
+    Command(String),
+    Callback(PreviewCallback),
+}
+
 impl Previewer {
-    pub fn new_from_command<C>(preview_cmd: Option<String>, callback: C) -> Self
+    pub fn new<C>(source: PreviewSource, callback: C) -> Self
     where
         C: Fn() + Send + Sync + 'static,
     {
@@ -105,77 +112,16 @@ impl Previewer {
         Self {
             tx_preview,
             content_lines,
-
             width,
             height,
             hscroll_offset,
             vscroll_offset,
             wrap: false,
-
             prev_item: None,
             prev_query: None,
             prev_cmd_query: None,
             prev_num_selected: 0,
-
-            preview_cmd,
-            preview_cb: None,
-            preview_offset: "".to_string(),
-            delimiter: Regex::new(DELIMITER_STR).unwrap(),
-            thread_previewer: Some(thread_previewer),
-        }
-    }
-
-    pub fn new_with_callback<C>(user_callback: PreviewCallback, callback: C) -> Self
-    where
-        C: Fn() + Send + Sync + 'static,
-    {
-        let content_lines = Arc::new(SpinLock::new(Vec::new()));
-        let (tx_preview, rx_preview) = channel();
-        let width = Arc::new(AtomicUsize::new(80));
-        let height = Arc::new(AtomicUsize::new(60));
-        let hscroll_offset = Arc::new(AtomicUsize::new(1));
-        let vscroll_offset = Arc::new(AtomicUsize::new(1));
-
-        let content_clone = content_lines.clone();
-        let width_clone = width.clone();
-        let height_clone = height.clone();
-        let hscroll_offset_clone = hscroll_offset.clone();
-        let vscroll_offset_clone = vscroll_offset.clone();
-        let thread_previewer = thread::spawn(move || {
-            run(rx_preview, move |lines, pos| {
-                let width = width_clone.load(Ordering::SeqCst);
-                let height = height_clone.load(Ordering::SeqCst);
-
-                let hscroll = pos.h_scroll.calc_fixed_size(lines.len(), 0);
-                let hoffset = pos.h_offset.calc_fixed_size(width, 0);
-                let vscroll = pos.v_scroll.calc_fixed_size(usize::MAX, 0);
-                let voffset = pos.v_offset.calc_fixed_size(height, 0);
-
-                hscroll_offset_clone.store(max(1, max(hscroll, hoffset) - hoffset), Ordering::SeqCst);
-                vscroll_offset_clone.store(max(1, max(vscroll, voffset) - voffset), Ordering::SeqCst);
-                *content_clone.lock() = lines;
-
-                callback();
-            })
-        });
-
-        Self {
-            tx_preview,
-            content_lines,
-
-            width,
-            height,
-            hscroll_offset,
-            vscroll_offset,
-            wrap: false,
-
-            prev_item: None,
-            prev_query: None,
-            prev_cmd_query: None,
-            prev_num_selected: 0,
-
-            preview_cmd: None,
-            preview_cb: Some(user_callback),
+            preview_source: source,
             preview_offset: "".to_string(),
             delimiter: Regex::new(DELIMITER_STR).unwrap(),
             thread_previewer: Some(thread_previewer),
@@ -301,9 +247,9 @@ impl Previewer {
                         PreviewEvent::PreviewCommand(preview_command, pos)
                     }
                 }
-                (ItemPreview::Global, _) => {
-                    if let Some(cmd) = self.preview_cmd.as_ref() {
-                        if depends_on_items(&cmd) && self.prev_item.is_none() {
+                (ItemPreview::Global, _) => match &self.preview_source {
+                    PreviewSource::Command(cmd) => {
+                        if depends_on_items(cmd) && self.prev_item.is_none() {
                             debug!("the command for preview refers to items and currently there is no item");
                             debug!("command to execute: [{}]", cmd);
                             PreviewEvent::PreviewPlainText("no item matched".to_string(), Default::default())
@@ -313,15 +259,15 @@ impl Previewer {
                             let preview_command = PreviewCommand { cmd, columns, lines };
                             PreviewEvent::PreviewCommand(preview_command, pos)
                         }
-                    } else if let Some(cb) = self.preview_cb.as_ref() {
+                    }
+                    PreviewSource::Callback(cb) => {
                         let pos = self.eval_scroll_offset(inject_context);
                         let selection: Vec<String> = selected_texts.into_iter().map(ToOwned::to_owned).collect();
                         let cb = cb.clone();
                         PreviewEvent::PreviewCallback(Box::new(move || cb(selection)), pos)
-                    } else {
-                        PreviewEvent::Noop
                     }
-                }
+                    PreviewSource::Empty => PreviewEvent::Noop,
+                },
             },
             None => PreviewEvent::Noop,
         };

--- a/skim/src/selection.rs
+++ b/skim/src/selection.rs
@@ -258,6 +258,11 @@ impl Selection {
             .items
             .get(cursor)
             .unwrap_or_else(|| panic!("model:act_toggle: failed to get item {}", cursor));
+        trace!(
+            "Toggling item {} with idx {}",
+            current_item.item.text(),
+            current_item.item_idx
+        );
         let index = (current_run_num(), current_item.item_idx);
         if !self.selected.contains_key(&index) {
             self.selected.insert(index, current_item.item.clone());


### PR DESCRIPTION
The _preview_  feature of skim is great, however when skim is used as a library, there's no way to render a preview from Rust code.

This PR adds a new option to SkimOptionsBuilder:
```rust
.preview_fn(| items: Vec<String> | -> Vec<AnsiString<'static>> {})
```
The closure will be called with the currently selected items to render.
