### PR TITLE
Pass --cmd-history instead of --history for interactive commands in vim

### DIFF
--- a/plugin/skim.vim
+++ b/plugin/skim.vim
@@ -342,6 +342,12 @@ function! skim#wrap(...)
     endif
   endif
 
+  " Interactive commands should use --cmd-history for query history
+  let history_option = '--history'
+  if index(opts['options'], '-i') != -1
+    let history_option = '--cmd-history'
+  endif
+
   " Colors: g:skim_colors
   let opts.options = s:defaults() .' '. s:evaluate_opts(get(opts, 'options', ''))
 
@@ -352,7 +358,7 @@ function! skim#wrap(...)
       call mkdir(dir, 'p')
     endif
     let history = skim#shellescape(dir.'/'.name)
-    let opts.options = join(['--history', history, opts.options])
+    let opts.options = join([history_option, history, opts.options])
   endif
 
   " Action: g:skim_action


### PR DESCRIPTION
Hey! Noticed that history navigation for interactive `rg` invocations via skim had either stopped working or not worked at all.

Found that it just wasn't putting anything in the history file, even though `g:skim_history_dir` was set, and followed it back to this.

This patch makes the vim plugin check if the `-i` flag is passed, and if so passes the history file as `--cmd-history` instead of `--history`. This seems to resolve the issue without breaking history for e.g. `Buffers`.

Have a good one! :)