### PR TITLE
ansi parser: fix dim / half-bright

### DIFF
--- a/src/ansi.rs
+++ b/src/ansi.rs
@@ -75,7 +75,7 @@ impl Perform for ANSIParser {
             match code[0] {
                 0 => attr = Attr::default(),
                 1 => attr.effect |= Effect::BOLD,
-                2 => attr.effect |= !Effect::BOLD,
+                2 => attr.effect |= Effect::DIM,
                 4 => attr.effect |= Effect::UNDERLINE,
                 5 => attr.effect |= Effect::BLINK,
                 7 => attr.effect |= Effect::REVERSE,
@@ -605,5 +605,22 @@ mod tests {
         assert_eq!(Some(('あ', Attr::default())), it.next());
         assert_eq!(Some(('a', highlight)), it.next());
         assert_eq!(None, it.next());
+    }
+
+    #[test]
+    fn test_ansi_dim() {
+        // https://github.com/lotabout/skim/issues/495
+        let input = "\x1B[2mhi\x1b[0m";
+        let ansistring = ANSIParser::default().parse_ansi(input);
+        let mut it = ansistring.iter();
+        let attr = Attr {
+            effect: Effect::DIM,
+            ..Attr::default()
+        };
+
+        assert_eq!(Some(('h', attr)), it.next());
+        assert_eq!(Some(('i', attr)), it.next());
+        assert_eq!(None, it.next());
+        assert_eq!(ansistring.stripped(), "hi");
     }
 }


### PR DESCRIPTION
`\x1b[2m` seems to be parsed as `DIM | UNDERLINE | BLINK | REVERSE` instead of just `DIM`.

Not sure why the current implementation does this, the message for the commit that added it just mentions implementing multiple parameters, but not specifically why !BOLD was added:

```diff
commit d902d65fae1294d7dea5f3dcd90ad31b5b55d1f9
Author: Jinzhou Zhang <lotabout@gmail.com>
Date:   Sat Jul 13 23:41:28 2019 +0800

    fix #194: color not working with ag

    It's because ag uses multiple attributes in SGR parameters.
    e.g. `\e[1;31m` which means set the attribute to BOLD and forground
    color to yellow.

    Previously skim's CSI parsing logic will take only the first parameter.

diff --git a/src/ansi.rs b/src/ansi.rs
index 8495d82..583d19b 100644
--- a/src/ansi.rs
+++ b/src/ansi.rs
@@ -69,60 +70,88 @@ impl Perform for ANSIParser {
         }
:
                 0 => attr = Attr::default(),
                 1 => attr.effect |= Effect::BOLD,
+                2 => attr.effect |= !Effect::BOLD,
                 4 => attr.effect |= Effect::UNDERLINE,
                 5 => attr.effect |= Effect::BLINK,
:
```

None of the tests added in this commit use DIM either, they still pass after my change, so I'm assuming this change was accidental.
