### PR TITLE
feat!: do not check for expect before printing the argument of accept…

### DIFF
--- a/skim/src/bin/main.rs
+++ b/skim/src/bin/main.rs
@@ -129,14 +129,8 @@ fn sk_main() -> Result<i32, SkMainError> {
         print!("{}{}", result.cmd, bin_options.output_ending);
     }
 
-    match result.final_event {
-        Event::EvActAccept(Some(accept_key)) => {
-            print!("{}{}", accept_key, bin_options.output_ending);
-        }
-        Event::EvActAccept(None) => {
-            print!("{}", bin_options.output_ending);
-        }
-        _ => {}
+    if let Event::EvActAccept(Some(accept_key)) = result.final_event {
+        print!("{}{}", accept_key, bin_options.output_ending);
     }
 
     for item in result.selected_items.iter() {

--- a/skim/src/bin/main.rs
+++ b/skim/src/bin/main.rs
@@ -129,16 +129,14 @@ fn sk_main() -> Result<i32, SkMainError> {
         print!("{}{}", result.cmd, bin_options.output_ending);
     }
 
-    if !opts.expect.is_empty() {
-        match result.final_event {
-            Event::EvActAccept(Some(accept_key)) => {
-                print!("{}{}", accept_key, bin_options.output_ending);
-            }
-            Event::EvActAccept(None) => {
-                print!("{}", bin_options.output_ending);
-            }
-            _ => {}
+    match result.final_event {
+        Event::EvActAccept(Some(accept_key)) => {
+            print!("{}{}", accept_key, bin_options.output_ending);
         }
+        Event::EvActAccept(None) => {
+            print!("{}", bin_options.output_ending);
+        }
+        _ => {}
     }
 
     for item in result.selected_items.iter() {

--- a/skim/src/options.rs
+++ b/skim/src/options.rs
@@ -222,7 +222,7 @@ pub struct SkimOptions {
     ///
     ///   ACTION:               DEFAULT BINDINGS (NOTES):
     ///     abort                 ctrl-c  ctrl-q  esc
-    ///     accept                enter
+    ///     accept(...)           enter (the argument will be printed when the binding is triggered)
     ///     append-and-select
     ///     backward-char         ctrl-b  left
     ///     backward-delete-char  ctrl-h  bspace

--- a/test/run.sh
+++ b/test/run.sh
@@ -4,6 +4,7 @@ set -euo pipefail
 
 TEST_CLASS=test_skim.TestSkim
 
+cd $(dirname "$0")
 tests=$(sed -n 's/^\s\+def \(test_\w\+\)(self.*):\s*$/\1/p' test_skim.py | \
   sk --multi)
 

--- a/test/test_skim.py
+++ b/test/test_skim.py
@@ -1375,6 +1375,17 @@ class TestSkim(TestBase):
         self.tmux.until(lambda l: l.ready_with_matches(2))
         self.tmux.until(lambda l: l[-3] == '> a b')
 
+    def test_624_accept_no_expect(self):
+        input_cmd = "echo -e 'a b c\\nd e f'"
+        args = '--bind ctrl-a:accept:hello'
+        self.tmux.send_keys(f"{input_cmd} | {self.sk(args)}", Key('Enter'))
+        self.tmux.until(lambda l: l.ready_with_matches(2))
+        self.tmux.send_keys(Ctrl('a'))
+        out = self.readonce().split('\n')
+        self.assertEqual(out[-1], '')
+        self.assertEqual(out[-2], 'a b c')
+        self.assertEqual(out[-3], 'hello')
+
 def find_prompt(lines, interactive=False, reverse=False):
     linen = -1
     prompt = ">"


### PR DESCRIPTION
…(...)

## Checklist

_check the box if it is not applicable to your changes_
- [x] I have updated the README with the necessary documentation
- [x] I have added unit tests
- [x] I have added [end-to-end tests](test/test_skim.py)
- [x] I have linked all related issues or PRs
- [x] I have re-generated the completions and manpage using `cargo xtask compgen` and `cargo xtask mangen`

## Description of the changes

- Do not require `--expect` to be able to print the argument of the `accept` binding
- Do not print an empty line if `--expect` is set but a different `accept` key is pressed
- Effectively starts the deprecation of `--expect <key>` in favor of `--bind:accept(<key>)`

closes #624 
