### PR TITLE
fix: Fix non-functional vim plugin

### DIFF
--- a/plugin/skim.vim
+++ b/plugin/skim.vim
@@ -937,6 +937,7 @@ function! s:popup(opts) abort
 endfunction
 
 let s:default_action = {
+  \ 'enter': 'edit',
   \ 'ctrl-t': 'tab split',
   \ 'ctrl-x': 'split',
   \ 'ctrl-v': 'vsplit' }


### PR DESCRIPTION
## Checklist

_check the box if it is not applicable to your changes_
- [x] I have updated the README with the necessary documentation
- [x] I have added unit tests
- [x] I have added [end-to-end tests](test/test_skim.py)
- [x] I have linked all related issues or PRs

## Description of the changes

The vim plugin uses --expect and expects the key used to accept the selection on the first line of output. Commit bcee1f4 "feat!: do not check for expect before printing the argument of accept… (#625)" broke that by not outputting anything if the selection was made using the default "enter" key. We can workaround that by explicitly adding "enter" to the --expect argument, so that it once again shows up in the output.

Fixes skim-rs/skim.vim#25