### PR TITLE
fix: update rank to follow the readded index tiebreak

### DIFF
--- a/skim/src/item.rs
+++ b/skim/src/item.rs
@@ -39,7 +39,7 @@ impl RankBuilder {
 
     /// score: the greater the better
     pub fn build_rank(&self, score: i32, begin: usize, end: usize, length: usize, index: usize) -> Rank {
-        let mut rank = [0; 4];
+        let mut rank = [0; 5];
         let begin = begin as i32;
         let end = end as i32;
         let length = length as i32;

--- a/skim/src/lib.rs
+++ b/skim/src/lib.rs
@@ -252,7 +252,7 @@ pub enum MatchRange {
     Chars(Vec<usize>), // individual character indices matched
 }
 
-pub type Rank = [i32; 4];
+pub type Rank = [i32; 5];
 
 #[derive(Clone)]
 pub struct MatchResult {


### PR DESCRIPTION
## Checklist

_check the box if it is not applicable to your changes_
- [x] I have updated the README with the necessary documentation
- [ ] I have added unit tests
- [ ] I have added [end-to-end tests](test/test_skim.py)
- [x] I have linked all related issues or PRs

## Description of the changes

Added two changes missing from the original commit that are needed so that there are no out of bounds accesses.

Have not made any changes to tests as this is a minor fix, the functionality of which should be adequately covered by existing tests.