### PR TITLE
doc(readme): correct fzf library statement in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -484,12 +484,12 @@ in Rust!
 This project is written from scratch. Some decisions of implementation are
 different from fzf. For example:
 
-1. `skim` is a binary as well as a library while fzf is only a binary.
+1. ~~`skim` is a binary as well as a library while fzf is only a binary.~~: fzf is actually a library too, but not documented.
 2. `skim` has an interactive mode.
-3. `skim` supports pre-selection
+3. `skim` supports pre-selection.
 4. The fuzzy search algorithm is different.
-5. ~~UI of showing matched items. `fzf` will show only the range matched while
-   `skim` will show each character matched.~~ (fzf has this now)
+5. ~~UI of showing matched items. `fzf` will show only the range matched while.
+   `skim` will show each character matched.~~: fzf has this now.
 6. ~~`skim`'s range syntax is Git style~~: now it is the same with fzf.
 
 # How to contribute

--- a/README.md
+++ b/README.md
@@ -327,7 +327,7 @@ sk --bind 'f1:execute(less -f {}),ctrl-y:execute-silent(echo {} | pbcopy)+abort'
 This is a great feature of fzf that skim borrows. For example, we use 'ag' to
 find the matched lines, and once we narrow down to the target lines, we want to
 finally decide which lines to pick by checking the context around the line.
-`grep` and `ag` have the option `--context`, and skim can make use of `--context` for 
+`grep` and `ag` have the option `--context`, and skim can make use of `--context` for
 a better preview window. For example:
 
 ```sh
@@ -484,13 +484,12 @@ in Rust!
 This project is written from scratch. Some decisions of implementation are
 different from fzf. For example:
 
-1. ~~`skim` is a binary as well as a library while fzf is only a binary.~~: fzf is actually a library too, but not clearly documented.
-2. `skim` has an interactive mode.
-3. `skim` supports pre-selection.
-4. The fuzzy search algorithm is different.
-5. ~~UI of showing matched items. `fzf` will show only the range matched while.
-   `skim` will show each character matched.~~: fzf has this now.
-6. ~~`skim`'s range syntax is Git style~~: now it is the same with fzf.
+1. `skim` has an interactive mode.
+2. `skim` supports pre-selection.
+3. The fuzzy search algorithm is different.
+
+More generally, `skim`'s maintainers allow themselves some freedom of implementation.
+The goal is to keep `skim` as feature-full as `fzf` is, but the command flags might differ.
 
 # How to contribute
 

--- a/README.md
+++ b/README.md
@@ -484,7 +484,7 @@ in Rust!
 This project is written from scratch. Some decisions of implementation are
 different from fzf. For example:
 
-1. ~~`skim` is a binary as well as a library while fzf is only a binary.~~: fzf is actually a library too, but not documented.
+1. ~~`skim` is a binary as well as a library while fzf is only a binary.~~: fzf is actually a library too, but not clearly documented.
 2. `skim` has an interactive mode.
 3. `skim` supports pre-selection.
 4. The fuzzy search algorithm is different.


### PR DESCRIPTION
## Checklist

- [x] I have updated the README with the necessary documentation
- [x] I have added unit tests
- [x] I have added [end-to-end tests](test/test_skim.py)
- [x] I have linked all related issues or PRs

## Description of the changes

The "_Differences from fzf_" section of the README states that "_skim is a binary as well as a library while fzf is only a binary_", but it's actually wrong. fzf is a library too, as every Go repo is, if you export your fields and functions correctly (which is true for fzf).  
It's right, though, that using fzf as library is not clearly documented, so I stated it like this in the README.  
(The Go doc still exists, like for all Go packages: [pkg.go.dev/github.com/junegunn/fzf](https://pkg.go.dev/github.com/junegunn/fzf@v0.57.0/src))

See a list of repositories importing fzf as a library here: [GitHub Search](https://github.com/search?q=junegunn%2Ffzf%2Fsrc+language%3AGo&type=code&ref=advsearch&p=2&l=Go)  
And a personal example: [alexandregv/worktree@0219f5b/main.go](https://github.com/alexandregv/worktree/blob/0219f5bd6ae78a96790bcb8375bf75e4316e7c18/main.go#L20-L66)