### PR TITLE
chore: fix clippy warning in rust 1.84

### DIFF
--- a/skim/examples/cmd_collector.rs
+++ b/skim/examples/cmd_collector.rs
@@ -8,7 +8,7 @@ struct BasicSkimItem {
 
 impl SkimItem for BasicSkimItem {
     fn text(&self) -> Cow<str> {
-        return Cow::Borrowed(&self.value);
+        Cow::Borrowed(&self.value)
     }
 }
 

--- a/skim/examples/selector.rs
+++ b/skim/examples/selector.rs
@@ -7,7 +7,7 @@ struct BasicSelector {
 
 impl Selector for BasicSelector {
     fn should_select(&self, _index: usize, item: &dyn SkimItem) -> bool {
-        return item.text().contains(&self.pat);
+        item.text().contains(&self.pat)
     }
 }
 

--- a/skim/src/ansi.rs
+++ b/skim/src/ansi.rs
@@ -357,7 +357,7 @@ impl<'a> AnsiStringIterator<'a> {
     }
 }
 
-impl<'a> Iterator for AnsiStringIterator<'a> {
+impl Iterator for AnsiStringIterator<'_> {
     type Item = (char, Attr);
 
     fn next(&mut self) -> Option<Self::Item> {

--- a/skim/src/item.rs
+++ b/skim/src/item.rs
@@ -210,7 +210,7 @@ pub struct ItemPoolGuard<'a, T: Sized + 'a> {
     start: usize,
 }
 
-impl<'mutex, T: Sized> Deref for ItemPoolGuard<'mutex, T> {
+impl<T: Sized> Deref for ItemPoolGuard<'_, T> {
     type Target = [T];
 
     fn deref(&self) -> &[T] {

--- a/skim/src/orderedvec.rs
+++ b/skim/src/orderedvec.rs
@@ -84,7 +84,7 @@ impl<T: Send + Ord + 'static> OrderedVec<T> {
         );
     }
 
-    fn sort_vector(&self, vec: &mut Vec<T>, asc: bool) {
+    fn sort_vector(&self, vec: &mut [T], asc: bool) {
         let asc = asc ^ self.tac;
         vec.par_sort();
         if !asc {

--- a/skim/src/spinlock.rs
+++ b/skim/src/spinlock.rs
@@ -30,7 +30,7 @@ impl<'a, T: ?Sized + 'a> SpinLockGuard<'a, T> {
     }
 }
 
-unsafe impl<'a, T: ?Sized + Sync> Sync for SpinLockGuard<'a, T> {}
+unsafe impl<T: ?Sized + Sync> Sync for SpinLockGuard<'_, T> {}
 
 impl<T> SpinLock<T> {
     pub fn new(t: T) -> SpinLock<T> {
@@ -52,7 +52,7 @@ impl<T: ?Sized> SpinLock<T> {
     }
 }
 
-impl<'mutex, T: ?Sized> Deref for SpinLockGuard<'mutex, T> {
+impl<T: ?Sized> Deref for SpinLockGuard<'_, T> {
     type Target = T;
 
     fn deref(&self) -> &T {
@@ -60,13 +60,13 @@ impl<'mutex, T: ?Sized> Deref for SpinLockGuard<'mutex, T> {
     }
 }
 
-impl<'mutex, T: ?Sized> DerefMut for SpinLockGuard<'mutex, T> {
+impl<T: ?Sized> DerefMut for SpinLockGuard<'_, T> {
     fn deref_mut(&mut self) -> &mut T {
         unsafe { &mut *self.__lock.data.get() }
     }
 }
 
-impl<'a, T: ?Sized> Drop for SpinLockGuard<'a, T> {
+impl<T: ?Sized> Drop for SpinLockGuard<'_, T> {
     #[inline]
     fn drop(&mut self) {
         while self

--- a/skim/src/util.rs
+++ b/skim/src/util.rs
@@ -48,7 +48,6 @@ pub fn escape_single_quote(text: &str) -> String {
 ///             |<-    shift    -> |
 /// |< hscroll >|
 /// ```
-
 pub struct LinePrinter {
     start: usize,
     end: usize,


### PR DESCRIPTION
## Checklist

_check the box if it is not applicable to your changes_
- [x] I have updated the README with the necessary documentation
- [x] I have added unit tests
- [x] I have added [end-to-end tests](test/test_skim.py)
- [x] I have linked all related issues or PRs

## Description of the changes

