### PR TITLE
chore: release

### DIFF
--- a/.github/release-plz.toml
+++ b/.github/release-plz.toml
@@ -58,16 +58,12 @@ body = """
 {%- macro username(commit) -%}
     {% if commit.remote.username %} (by @{{ commit.remote.username }}){% endif -%}
 {% endmacro -%}
-{%- macro pr(commit) -%}
-    {% if commit.remote.pr_number %} - #{{ commit.remote.pr_number }}{% endif -%}
-{% endmacro -%}
 {% macro print_commit(commit) -%}
-    - {% if commit.scope %}*({{ commit.scope }})* {% endif %}\
+    - {% if commit.scope %}**{{ commit.scope }}:** {% endif %}\
       {% if commit.breaking %}[**breaking**] {% endif %}\
       {{ commit.message | upper_first }} - \
       ([{{ commit.id | truncate(length=7, end="") }}]({{ remote.link }}/commit/{{ commit.id }}))\
 			{{ self::username(commit=commit) }}\
-      {{ self::pr(commit=commit) }}\
 {% endmacro -%}
 
 {% if version %}\

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -120,55 +120,6 @@
 * undo sk-tmux deprecation ([c9f9025](https://github.com/skim-rs/skim/commit/c9f9025da9cf0bae7802f725eebd28ebac324378))
 
 
-### Miscellaneous Chores
-
-* release 0.14.4 ([0f2e061](https://github.com/skim-rs/skim/commit/0f2e0612522c8d046af1f283f264ee6af76b9232))
-
-## [0.14.4](https://github.com/skim-rs/skim/compare/v0.14.4...v0.14.4) (2024-11-30)
-
-
-### ⚠ BREAKING CHANGES
-
-* do not check for expect before printing the argument of accept… ([#625](https://github.com/skim-rs/skim/issues/625))
-
-### Features
-
-* add `--tmux` flag (deprecates sk-tmux, fixes [#596](https://github.com/skim-rs/skim/issues/596)) ([#603](https://github.com/skim-rs/skim/issues/603)) ([a2d8c3f](https://github.com/skim-rs/skim/commit/a2d8c3f6022197727b3907562068053a8326a2a2))
-* add reload action ([#604](https://github.com/skim-rs/skim/issues/604)) ([4b47244](https://github.com/skim-rs/skim/commit/4b47244922c8910930d5c02016b1c5e99409754a))
-* allow more flexibility for use as a library ([#613](https://github.com/skim-rs/skim/issues/613)) ([33ca402](https://github.com/skim-rs/skim/commit/33ca4023c16b20a4ba6f3e1889efddd78ead15d6))
-* do not check for expect before printing the argument of accept… ([#625](https://github.com/skim-rs/skim/issues/625)) ([bcee1f4](https://github.com/skim-rs/skim/commit/bcee1f4c028012a24ef7ebbda1f80c0decb2375e))
-* readd index tiebreak ([#609](https://github.com/skim-rs/skim/issues/609)) ([0befe8d](https://github.com/skim-rs/skim/commit/0befe8d20659ef90b564f59c07a908ab0953dc0a))
-* **tui:** add info hidden ([#630](https://github.com/skim-rs/skim/issues/630)) ([b0868e8](https://github.com/skim-rs/skim/commit/b0868e849a64265618696c071b963b89577f46cd))
-* use clap & derive for options, manpage & completions ([#586](https://github.com/skim-rs/skim/issues/586)) ([7df8b77](https://github.com/skim-rs/skim/commit/7df8b77739ae5a05e8cd87bff905ee091e5afd7f))
-
-
-### Bug Fixes
-
-* allow combined multiple args (fixes [#622](https://github.com/skim-rs/skim/issues/622)) ([#623](https://github.com/skim-rs/skim/issues/623)) ([4144879](https://github.com/skim-rs/skim/commit/4144879f00f6a541637112bdb96e23101eb4acda))
-* undo sk-tmux deprecation ([c9f9025](https://github.com/skim-rs/skim/commit/c9f9025da9cf0bae7802f725eebd28ebac324378))
-
-
-### Miscellaneous Chores
-
-* release 0.14.4 ([0f2e061](https://github.com/skim-rs/skim/commit/0f2e0612522c8d046af1f283f264ee6af76b9232))
-
-## [0.14.4](https://github.com/skim-rs/skim/compare/v0.14.3...v0.14.4) (2024-11-30)
-
-
-### Features
-
-* **tui:** add info hidden ([#630](https://github.com/skim-rs/skim/issues/630)) ([b0868e8](https://github.com/skim-rs/skim/commit/b0868e849a64265618696c071b963b89577f46cd))
-
-
-### Bug Fixes
-
-* undo sk-tmux deprecation ([c9f9025](https://github.com/skim-rs/skim/commit/c9f9025da9cf0bae7802f725eebd28ebac324378))
-
-
-### Miscellaneous Chores
-
-* release 0.14.4 ([0f2e061](https://github.com/skim-rs/skim/commit/0f2e0612522c8d046af1f283f264ee6af76b9232))
-
 ## [0.15.0](https://github.com/skim-rs/skim/compare/v0.14.4...v0.15.0) (2024-11-30)
 
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,22 @@
+# Changelog
+
+## [Unreleased]
+## [0.17.0](https://github.com/skim-rs/skim/compare/v0.16.2...v0.17.0)
+
+### ⛰️ Features
+
+
+- **shell:** Readd completions ([#726](https://github.com/skim-rs/skim/pull/726)) ([#739](https://github.com/skim-rs/skim/pull/739)) - ([f87ff67](https://github.com/skim-rs/skim/commit/f87ff6740b20794eaf6288b901f85b7737a28bcf)) (by @LoricAndre)
+- **tui:** Add tuikit as workspace member and update ([#741](https://github.com/skim-rs/skim/pull/741)) - ([73fd406](https://github.com/skim-rs/skim/commit/73fd4068274bda836b71bffaf5d41d4746b29a0d)) (by @LoricAndre)
+
+### ⚙️ Miscellaneous Tasks
+
+
+- **ci:** Migrate to release-plz - ([adc4298](https://github.com/skim-rs/skim/commit/adc4298f94daa283843aa435ed428704f85e8706))
+
+### Contributors
+
+* @LoricAndre
 
 ## [0.16.2](https://github.com/skim-rs/skim/compare/v0.16.1...v0.16.2) (2025-04-26)
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -902,7 +902,7 @@ checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
 
 [[package]]
 name = "skim"
-version = "0.16.2"
+version = "0.17.0"
 dependencies = [
  "beef",
  "bitflags 1.3.2",

--- a/man/man1/sk.1
+++ b/man/man1/sk.1
@@ -1,6 +1,6 @@
 .ie \n(.g .ds Aq \(aq
 .el .ds Aq '
-.TH sk 1  "sk 0.16.2" 
+.TH sk 1  "sk 0.17.0" 
 .SH NAME
 sk \- sk \- fuzzy finder in Rust
 .SH SYNOPSIS
@@ -687,4 +687,4 @@ Pre\-select the items read from this file
 \fB\-f\fR, \fB\-\-filter\fR=\fIFILTER\fR
 Query for filter mode
 .SH VERSION
-v0.16.2
+v0.17.0

--- a/skim/Cargo.toml
+++ b/skim/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "skim"
-version = "0.16.2"
+version = "0.17.0"
 authors = ["Zhang Jinzhou <lotabout@gmail.com>", "Loric Andre"]
 description = "Fuzzy Finder in rust!"
 documentation = "https://docs.rs/skim"


### PR DESCRIPTION



## 🤖 New release

* `skim`: 0.16.2 -> 0.17.0

<details><summary><i><b>Changelog</b></i></summary><p>



</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).