### PR TITLE
fix(tmux): force sh as shell for tmux mode

### DIFF
--- a/man/man1/sk.1
+++ b/man/man1/sk.1
@@ -1,6 +1,6 @@
 .ie \n(.g .ds Aq \(aq
 .el .ds Aq '
-.TH sk 1  "sk 0.17.0" 
+.TH sk 1  "sk 0.17.1" 
 .SH NAME
 sk \- sk \- fuzzy finder in Rust
 .SH SYNOPSIS
@@ -687,4 +687,4 @@ Pre\-select the items read from this file
 \fB\-f\fR, \fB\-\-filter\fR=\fIFILTER\fR
 Query for filter mode
 .SH VERSION
-v0.17.0
+v0.17.1

--- a/skim/src/tmux.rs
+++ b/skim/src/tmux.rs
@@ -187,7 +187,7 @@ pub fn run_with(opts: &SkimOptions) -> Option<SkimOutput> {
         }
     }
 
-    tmux_cmd.arg(tmux_shell_cmd);
+    tmux_cmd.args(["sh", "-c", &tmux_shell_cmd]);
 
     debug!("tmux command: {:?}", tmux_cmd);
 


### PR DESCRIPTION
## Checklist

_check the box if it is not applicable to your changes_
- [ ] I have updated the README with the necessary documentation
- [ ] I have added unit tests
- [ ] I have added [end-to-end tests](test/test_skim.py)
- [ ] I have linked all related issues or PRs

## Description of the changes

When running `sk --tmux` with non-POSIX shells, commands would often error out because of syntax conflicts. This forces the popup command to run with `sh`. 
