### PR TITLE
bash: set keybinding right before printing special character

### DIFF
--- a/shell/key-bindings.bash
+++ b/shell/key-bindings.bash
@@ -114,9 +114,6 @@ fi
 
 ###########################################################
 
-# To redraw line after skim closes (printf '\e[5n')
-bind '"\e[0n": redraw-current-line'
-
 __skim_comprun() {
   if [ "$(type -t _skim_comprun 2>&1)" = function ]; then
     _skim_comprun "$@"
@@ -187,6 +184,8 @@ __skim_generic_path_completion() {
         else
           COMPREPLY=( "$cur" )
         fi
+        # To redraw line after skim closes (printf '\e[5n')
+        bind '"\e[0n": redraw-current-line'
         printf '\e[5n'
         return 0
       fi
@@ -240,6 +239,8 @@ _skim_complete() {
     else
       COMPREPLY=("$cur")
     fi
+    # To redraw line after skim closes (printf '\e[5n')
+    bind '"\e[0n": redraw-current-line'
     printf '\e[5n'
     echo -e "\033[0m"
     return 0


### PR DESCRIPTION
## Checklist

_check the box if it is not applicable to your changes_
- [x] I have updated the README with the necessary documentation
- [x] I have added unit tests
- [x] I have added [end-to-end tests](test/test_skim.py)
- [x] I have linked all related issues or PRs

## Description of the changes

Currently, fzf sets the `\e[0n` keybinding upon initialization, which is sadly the only way to call readline functions in Bash. Unfortunately, this method is also used by tools like [zoxide](https://github.com/ajeetdsouza/zoxide), causing the keybinding to be overridden:

https://github.com/ajeetdsouza/zoxide/blob/095b270fea283ed0a9d147c2b154a80030f19a4c/templates/bash.txt#L160

Since the only purpose of this particular keybinding appears to be to hack around this particular limitation of Bash, the way I've handled this issue in zoxide is to set the keybinding _right_ before calling it via `printf '\e[5n'`. This PR does the same for skim, to recover the keybinding after other plugins have potentially overridden it.

Context: I'm the author of zoxide, just trying to ensure our plugins don't clash :)

Relevant PR: https://github.com/junegunn/fzf/pull/4377