### PR TITLE
Feature: add support for cycle flag

### DIFF
--- a/man/man1/sk.1
+++ b/man/man1/sk.1
@@ -397,6 +397,9 @@ Disable multiple selection
 \fB\-\-no\-mouse\fR
 Disable mouse
 .TP
+\fB\-\-cycle\fR
+Enable cyclic scroll
+.TP
 \fB\-c\fR, \fB\-\-cmd\fR=\fICMD\fR
 Command to invoke dynamically in interactive mode
 

--- a/skim/src/options.rs
+++ b/skim/src/options.rs
@@ -870,8 +870,8 @@ pub struct SkimOptions {
     #[arg(long, hide = true, help_heading = "Reserved for later use")]
     pub literal: bool,
 
-    /// Reserved for later use
-    #[arg(long, hide = true, help_heading = "Reserved for later use")]
+    /// Enable cyclic scroll
+    #[arg(long, default_value = "false", help_heading = "Enable cyclic scroll")]
     pub cycle: bool,
 
     /// Reserved for later use


### PR DESCRIPTION
## Checklist

_check the box if it is not applicable to your changes_
- [x] I have updated the README with the necessary documentation
- [x] I have added unit tests
- [x] I have added [end-to-end tests](test/test_skim.py)
- [x] I have linked all related issues or PRs

## Description of the changes

From this issue https://github.com/skim-rs/skim/issues/553 

When the --cycle flag is provided, going down from the first item will go to the last item, and going up from the last item will go to the first item. 

Functions similarly to fzf, so it will only cycle from that item. That is, if page down is pressed, the selection will stop at the first item, and pressing it again will cycle