### PR TITLE
Feature: add support for cycle flag

### DIFF
--- a/e2e/tests/options.rs
+++ b/e2e/tests/options.rs
@@ -862,3 +862,12 @@ fn opt_cycle() -> Result<()> {
     tmux.until(|l| l[0].starts_with(">"))?;
     Ok(())
 }
+#[test]
+fn opt_cycle_reverse() -> Result<()> {
+    let (tmux, _) = setup("1\\n2\\n3\\n4\\n5", &["--cycle", "--reverse"])?;
+    tmux.send_keys(&[Ctrl(&Key('k'))])?;
+    tmux.until(|l| l[l.len() - 1].starts_with(">"))?;
+    tmux.send_keys(&[Ctrl(&Key('j'))])?;
+    tmux.until(|l| l[0].starts_with(">"))?;
+    Ok(())
+}

--- a/e2e/tests/options.rs
+++ b/e2e/tests/options.rs
@@ -608,7 +608,6 @@ fn opt_reserved_options() -> Result<()> {
         "--extended",
         "--literal",
         "--no-mouse",
-        "--cycle",
         "--hscroll-off=10",
         "--filepath-word",
         "--jump-labels=CHARS",
@@ -851,5 +850,15 @@ fn opt_accept_arg() -> Result<()> {
     let output = tmux.output(&outfile)?;
     assert_eq!(output[0], "a");
     assert_eq!(output[1], "hello");
+    Ok(())
+}
+
+#[test]
+fn opt_cycle() -> Result<()> {
+    let (tmux, _) = setup("1\\n2\\n3\\n4\\n5", &["--cycle"])?;
+    tmux.send_keys(&[Ctrl(&Key('j'))])?;
+    tmux.until(|l| l[l.len() - 1].starts_with(">"))?;
+    tmux.send_keys(&[Ctrl(&Key('k'))])?;
+    tmux.until(|l| l[0].starts_with(">"))?;
     Ok(())
 }

--- a/man/man1/sk.1
+++ b/man/man1/sk.1
@@ -397,6 +397,9 @@ Disable multiple selection
 \fB\-\-no\-mouse\fR
 Disable mouse
 .TP
+\fB\-\-cycle\fR
+Enable cyclic scroll
+.TP
 \fB\-c\fR, \fB\-\-cmd\fR=\fICMD\fR
 Command to invoke dynamically in interactive mode
 

--- a/skim/src/options.rs
+++ b/skim/src/options.rs
@@ -870,8 +870,8 @@ pub struct SkimOptions {
     #[arg(long, hide = true, help_heading = "Reserved for later use")]
     pub literal: bool,
 
-    /// Reserved for later use
-    #[arg(long, hide = true, help_heading = "Reserved for later use")]
+    /// Enable cyclic scroll
+    #[arg(long, default_value = "false", help_heading = "Enable cyclic scroll")]
     pub cycle: bool,
 
     /// Reserved for later use


### PR DESCRIPTION
## Checklist

_check the box if it is not applicable to your changes_
- [x] I have updated the README with the necessary documentation
- [x] I have added unit tests
- [x] I have added [end-to-end tests](test/test_skim.py)
- [x] I have linked all related issues or PRs

## Description of the changes
From this issue https://github.com/skim-rs/skim/issues/553

When the --cycle flag is provided, going down from the first item will go to the last item, and going up from the last item will go to the first item.

Functions similarly to fzf, so it will only cycle from that item. That is, if page down is pressed, the selection will stop at the first item, and pressing it again will cycle

This adds fixes discussed in https://github.com/skim-rs/skim/pull/796#issue-3125665195. I accidentally closed my previous PR when trying to fix it, as I am still learning how to use git correctly