### PR TITLE
fix(shell): make awk regex compatible with macOS default awk

### DIFF
--- a/shell/key-bindings.zsh
+++ b/shell/key-bindings.zsh
@@ -133,7 +133,7 @@ bindkey '\ec' skim-cd-widget
 skim-history-widget() {
   local selected num
   setopt localoptions noglobsubst noposixbuiltins pipefail no_aliases 2> /dev/null
-  local awk_filter='{ cmd=$0; sub(/^\s*[0-9]+\**\s+/, "", cmd); if (!seen[cmd]++) print $0 }'  # filter out duplicates
+  local awk_filter='{ cmd=$0; sub(/^[ \t]*[0-9]+\**[ \t]+/, "", cmd); if (!seen[cmd]++) print $0 }'  # filter out duplicates
   local n=2 fc_opts=''
   if [[ -o extended_history ]]; then
     local today=$(date +%Y-%m-%d)


### PR DESCRIPTION
## Checklist

_check the box if it is not applicable to your changes_
- [ ] I have updated the README with the necessary documentation
- [ ] I have added unit tests
- [ ] I have added [end-to-end tests](test/test_skim.py)
- [ ] I have linked all related issues or PRs

## Description of the changes

Unlike GNU awk (gawk), the default awk on macOS does not support \s, making the previous expression not truly equivalent to the original perl command. This change replaces the entire first column with an empty string, achieving the same substitution effect in a portable way.

refs https://github.com/junegunn/fzf/pull/2906
