### PR TITLE
chore: Improve error handling for invalid regex delimiter

### DIFF
--- a/skim/src/model/mod.rs
+++ b/skim/src/model/mod.rs
@@ -191,10 +191,10 @@ impl Model {
     }
 
     fn parse_options(&mut self, options: &SkimOptions) {
-        let Ok(delimiter) = Regex::new(&options.delimiter) else {
-            panic!("Could not parse delimiter {} as a valid regex", options.delimiter);
-        };
-        self.delimiter = delimiter;
+        self.delimiter = Regex::new(&options.delimiter).unwrap_or_else(|_| {
+            eprintln!("Warning: Invalid regex delimiter '{}', falling back to default", options.delimiter);
+            Regex::new(r"[\t\n ]+").unwrap()
+        });
 
         self.layout = options.layout.clone();
 


### PR DESCRIPTION
Replace panic with graceful error handling when an invalid regex delimiter is provided. Instead of crashing the application, now:

- Shows a clear warning message to the user
- Falls back to the default delimiter pattern `[\t\n ]+`
- Allows the application to continue running normally

This prevents crashes from invalid user input while maintaining functionality and providing helpful feedback.

Fixes potential crashes when users provide malformed regex patterns as delimiters through command-line options.

