### PR TITLE
Feat/shell key bindings

### DIFF
--- a/README.md
+++ b/README.md
@@ -206,6 +206,35 @@ sk --shell fish > ~/.config/fish/completions/sk.fish
 
 ## Key Bindings
 
+You can generate shell completions for your preferred shell using the `--key-bindings` flag with one of the supported shells: `bash`, `zsh`, `fish`:
+
+#### Option 1: Source directly in your current shell session
+
+```sh
+# For bash
+source <(sk --key-bindings bash)
+
+# For zsh
+source <(sk --key-bindings zsh)
+
+# For fish
+sk --key-bindings fish | source
+```
+
+#### Option 2: Save to a file to be loaded automatically on shell startup
+
+```sh
+# For bash, add to ~/.bashrc
+echo 'source <(sk --key-bindings bash)' >> ~/.bashrc  # Or save to ~/.bash_completion
+
+# For zsh, add to ~/.zshrc
+sk --key-bindings zsh >> ~/.zshrc
+
+# For fish, add to ~/.config/fish/conf.d/
+sk --key-bindings fish > ~/.config/fish/conf.d/skim_key_bindings.fish
+source ~/.config/fish/conf.d/skim_key_bindings.fish
+```
+
 Some commonly used key bindings:
 
 | Key               | Action                                     |

--- a/skim/src/bin/main.rs
+++ b/skim/src/bin/main.rs
@@ -6,7 +6,7 @@ extern crate skim;
 extern crate time;
 
 use clap::{CommandFactory, Error, Parser};
-use clap_complete::generate;
+use clap_complete::{Shell, generate};
 
 use derive_builder::Builder;
 use std::fs::File;
@@ -80,9 +80,32 @@ fn sk_main() -> Result<i32, SkMainError> {
     let mut opts = parse_args()?;
 
     // Handle shell completion generation if requested
+    #[cfg(feature = "cli")]
     if let Some(shell) = opts.shell {
         // Generate completion script directly to stdout
         generate(shell, &mut SkimOptions::command(), "sk", &mut io::stdout());
+        return Ok(0);
+    }
+
+    // Handle key bindings generation if requested
+    #[cfg(feature = "cli")]
+    if let Some(shell) = opts.key_bindings {
+        // Generate key binding script directly to stdout
+
+        use std::{thread::sleep, time::Duration};
+        let script = match shell {
+            Shell::Bash => include_str!("../../../shell/key-bindings.bash"),
+            Shell::Fish => include_str!("../../../shell/key-bindings.fish"),
+            Shell::Zsh => include_str!("../../../shell/key-bindings.zsh"),
+            _ => unimplemented!(),
+        };
+        sleep(Duration::from_secs(10));
+        for line in script.lines()
+        /*.skip(1)*/
+        {
+            println!("{line}");
+        }
+
         return Ok(0);
     }
 

--- a/skim/src/options.rs
+++ b/skim/src/options.rs
@@ -884,6 +884,21 @@ pub struct SkimOptions {
     )]
     pub shell: Option<clap_complete::Shell>,
 
+    /// Generate key binding script
+    ///
+    /// Generate key binding script for the specified shell: bash, zsh, fish, etc.
+    /// The output can be directly sourced or saved to a file for automatic loading.
+    /// Examples: `source <(sk --key-bindings bash)` (immediate use)
+    ///          `sk --key-bindings bash >> ~/.bashrc` (persistent use)
+    ///
+    /// Supported shells: bash, zsh, fish
+    #[cfg(feature = "cli")]
+    #[cfg_attr(
+        feature = "cli",
+        arg(long, value_name = "SHELL", help_heading = "Scripting", value_enum)
+    )]
+    pub key_bindings: Option<clap_complete::Shell>,
+
     /// Run in a tmux popup
     ///
     /// Format: `sk --tmux <center|top|bottom|left|right>[,SIZE[%]][,SIZE[%]]`
@@ -1045,6 +1060,8 @@ impl Default for SkimOptions {
             filter: Default::default(),
             #[cfg(feature = "cli")]
             shell: Default::default(),
+            #[cfg(feature = "cli")]
+            key_bindings: Default::default(),
             tmux: Default::default(),
             extended: Default::default(),
             literal: Default::default(),
@@ -1097,6 +1114,7 @@ impl SkimOptions {
 
         self
     }
+
     pub fn init_histories(&mut self) {
         if let Some(histfile) = &self.history_file {
             self.query_history.extend(read_file_lines(histfile).unwrap_or_default());


### PR DESCRIPTION
## Checklist

_check the box if it is not applicable to your changes_
- [x] I have updated the README with the necessary documentation
- [ ] I have added unit tests
- [ ] I have added [end-to-end tests](test/test_skim.py)
- [x] I have linked all related issues or PRs

## Description of the changes

- Added a new `--key-bindings` flag to generate shell key bindings for Bash/Zsh/Fish.
- Updated README with usage instructions.

Related to #852 