### PR TITLE
Skim was removed from Fedora 43 repositories

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,7 +75,6 @@ The skim project contains several components:
 | -------------- | ----------------- | ---------------------------- |
 | macOS          | Homebrew          | `brew install sk`            |
 | macOS          | MacPorts          | `sudo port install skim`     |
-| Fedora         | dnf               | `dnf install skim`           |
 | Alpine         | apk               | `apk add skim`               |
 | Arch           | pacman            | `pacman -S skim`             |
 | Gentoo         | Portage           | `emerge --ask app-misc/skim` |


### PR DESCRIPTION
## Checklist

_check the box if it is not applicable to your changes_
- [x] I have updated the README with the necessary documentation
- [ ] I have added unit tests
- [ ] I have added [end-to-end tests](test/test_skim.py)
- [ ] I have linked all related issues or PRs

## Description of the changes

Fedora 43 removed skim, remove `dnf` command from README.md
