### PR TITLE
fix(tui): pass tiebreak options to matcher and sort items correctly

### DIFF
--- a/skim/src/tui/app.rs
+++ b/skim/src/tui/app.rs
@@ -3,7 +3,7 @@ use std::process::{Command, Stdio};
 use std::rc::Rc;
 use std::sync::Arc;
 
-use crate::item::{ItemPool, MatchedItem};
+use crate::item::{ItemPool, MatchedItem, RankBuilder};
 use crate::matcher::{Matcher, MatcherControl};
 use crate::model::options::InfoDisplay;
 use crate::prelude::ExactOrFuzzyEngineFactory;
@@ -269,6 +269,9 @@ impl<'a> App<'a> {
             }
         }
 
+        // Create RankBuilder from tiebreak options
+        let rank_builder = Arc::new(RankBuilder::new(options.tiebreak.clone()));
+
         Self {
             input,
             preview: {
@@ -285,7 +288,11 @@ impl<'a> App<'a> {
             item_tx,
             should_quit: false,
             cursor_pos: (0, 0),
-            matcher: Matcher::builder(Rc::new(ExactOrFuzzyEngineFactory::builder().build()))
+            matcher: Matcher::builder(Rc::new(
+                ExactOrFuzzyEngineFactory::builder()
+                    .rank_builder(rank_builder)
+                    .build()
+            ))
                 .case(options.case)
                 .build(),
             yank_register: Cow::default(),

--- a/skim/src/tui/item_list.rs
+++ b/skim/src/tui/item_list.rs
@@ -90,6 +90,7 @@ impl ItemList {
         let items_updated = if let Ok(items) = self.rx.try_recv() {
             debug!("Got {} items to put in list", items.len());
             self.items = items;
+            self.items.sort_by_key(|item| item.rank);
             true
         } else {
             false
@@ -237,7 +238,7 @@ impl Widget for &mut ItemList {
         if let Ok(items) = self.rx.try_recv() {
             debug!("Got {} items to put in list", items.len());
             self.items = items;
-            //self.items.sort_by_key(|item| std::cmp::Reverse(item.rank));
+            self.items.sort_by_key(|item| item.rank);
         }
 
         if self.items.is_empty() {


### PR DESCRIPTION
This fixes the tiebreak end-to-end tests by ensuring tiebreak options are properly used in the ratatui implementation:

1. Pass RankBuilder with tiebreak criteria to matcher factory
2. Sort matched items by rank in ascending order (correct for how ranks are calculated with negative scores for better matches)
3. Apply sorting in both render methods when receiving new items

All 10 tiebreak tests now pass (previously 9/10 were timing out).

## Checklist

_check the box if it is not applicable to your changes_
- [ ] I have updated the README with the necessary documentation
- [ ] I have added unit tests
- [ ] I have added [end-to-end tests](test/test_skim.py)
- [ ] I have linked all related issues or PRs

## Description of the changes

