### PR TITLE
feat: fn match_item need not include Arc

### DIFF
--- a/src/bin/main.rs
+++ b/src/bin/main.rs
@@ -353,7 +353,7 @@ pub fn filter(bin_option: &BinOptions, options: &SkimOptions, source: Option<Ski
 
     let mut matched_items: Vec<_> = items
         .iter()
-        .filter_map(|item| engine.match_item(item.clone()).map(|result| (item, result)))
+        .filter_map(|item| engine.match_item(item.as_ref()).map(|result| (item, result)))
         .collect();
 
     if options.tac {

--- a/src/engine/all.rs
+++ b/src/engine/all.rs
@@ -28,7 +28,7 @@ impl MatchAllEngine {
 }
 
 impl MatchEngine for MatchAllEngine {
-    fn match_item(&self, item: Arc<dyn SkimItem>) -> Option<MatchResult> {
+    fn match_item(&self, item: &dyn SkimItem) -> Option<MatchResult> {
         let item_len = item.text().len();
         Some(MatchResult {
             rank: self.rank_builder.build_rank(0, 0, 0, item_len, item.get_index()),

--- a/src/engine/andor.rs
+++ b/src/engine/andor.rs
@@ -1,5 +1,4 @@
 use std::fmt::{Display, Error, Formatter};
-use std::sync::Arc;
 
 use crate::{MatchEngine, MatchRange, MatchResult, SkimItem};
 
@@ -25,9 +24,9 @@ impl OrEngine {
 }
 
 impl MatchEngine for OrEngine {
-    fn match_item(&self, item: Arc<dyn SkimItem>) -> Option<MatchResult> {
+    fn match_item(&self, item: &dyn SkimItem) -> Option<MatchResult> {
         for engine in &self.engines {
-            let result = engine.match_item(Arc::clone(&item));
+            let result = engine.match_item(item);
             if result.is_some() {
                 return result;
             }
@@ -95,11 +94,11 @@ impl AndEngine {
 }
 
 impl MatchEngine for AndEngine {
-    fn match_item(&self, item: Arc<dyn SkimItem>) -> Option<MatchResult> {
+    fn match_item(&self, item: &dyn SkimItem) -> Option<MatchResult> {
         // mock
         let mut results = vec![];
         for engine in &self.engines {
-            let result = engine.match_item(Arc::clone(&item))?;
+            let result = engine.match_item(item)?;
             results.push(result);
         }
 

--- a/src/engine/exact.rs
+++ b/src/engine/exact.rs
@@ -74,7 +74,7 @@ impl ExactEngine {
 }
 
 impl MatchEngine for ExactEngine {
-    fn match_item(&self, item: Arc<dyn SkimItem>) -> Option<MatchResult> {
+    fn match_item(&self, item: &dyn SkimItem) -> Option<MatchResult> {
         let mut matched_result = None;
         let item_text = item.text();
         let default_range = [(0, item_text.len())];

--- a/src/engine/fuzzy.rs
+++ b/src/engine/fuzzy.rs
@@ -137,7 +137,7 @@ impl FuzzyEngine {
 }
 
 impl MatchEngine for FuzzyEngine {
-    fn match_item(&self, item: Arc<dyn SkimItem>) -> Option<MatchResult> {
+    fn match_item(&self, item: &dyn SkimItem) -> Option<MatchResult> {
         // iterate over all matching fields:
         let mut matched_result = None;
         let item_text = item.text();

--- a/src/engine/normalized.rs
+++ b/src/engine/normalized.rs
@@ -5,7 +5,6 @@
 
 use std::borrow::Cow;
 use std::fmt::{Display, Error, Formatter};
-use std::sync::Arc;
 
 use crate::engine::util::{map_byte_range_to_original, map_char_indices_to_original};
 use crate::engine::util::{normalize_with_byte_mapping, normalize_with_char_mapping};
@@ -25,7 +24,7 @@ impl NormalizedEngine {
 }
 
 impl MatchEngine for NormalizedEngine {
-    fn match_item(&self, item: Arc<dyn SkimItem>) -> Option<MatchResult> {
+    fn match_item(&self, item: &dyn SkimItem) -> Option<MatchResult> {
         let item_text = item.text();
 
         // Normalize the item text
@@ -33,7 +32,7 @@ impl MatchEngine for NormalizedEngine {
         let (_, byte_mapping) = normalize_with_byte_mapping(&item_text);
 
         // Create a wrapper item with normalized text
-        let normalized_item: Arc<dyn SkimItem> = Arc::new(NormalizedItem(normalized_text));
+        let normalized_item: &dyn SkimItem = &NormalizedItem(normalized_text);
 
         // Match using the inner engine
         let mut result = self.inner.match_item(normalized_item)?;

--- a/src/engine/regexp.rs
+++ b/src/engine/regexp.rs
@@ -46,7 +46,7 @@ impl RegexEngine {
 }
 
 impl MatchEngine for RegexEngine {
-    fn match_item(&self, item: Arc<dyn SkimItem>) -> Option<MatchResult> {
+    fn match_item(&self, item: &dyn SkimItem) -> Option<MatchResult> {
         let mut matched_result = None;
         let item_text = item.text();
         let default_range = [(0, item_text.len())];

--- a/src/engine/split.rs
+++ b/src/engine/split.rs
@@ -3,10 +3,8 @@
 //! This engine splits both the query and item text on a delimiter character, then matches
 //! the query parts against the corresponding item parts.
 
-use std::fmt::{Display, Error, Formatter};
-use std::sync::Arc;
-
 use crate::{MatchEngine, MatchEngineFactory, MatchRange, MatchResult, SkimItem};
+use std::fmt::{Display, Error, Formatter};
 
 /// Engine that matches by splitting query and item on a delimiter
 pub struct SplitMatchEngine {
@@ -30,7 +28,7 @@ impl SplitMatchEngine {
 }
 
 impl MatchEngine for SplitMatchEngine {
-    fn match_item(&self, item: Arc<dyn SkimItem>) -> Option<MatchResult> {
+    fn match_item(&self, item: &dyn SkimItem) -> Option<MatchResult> {
         let text = item.text();
 
         // Find the delimiter in the item text (by char position)
@@ -43,8 +41,8 @@ impl MatchEngine for SplitMatchEngine {
         let text_after = &text[delimiter_byte_pos + self.delimiter.len_utf8()..];
 
         // Create wrapper items for each part
-        let before_item: Arc<dyn SkimItem> = Arc::new(StringItem(text_before.to_string()));
-        let after_item: Arc<dyn SkimItem> = Arc::new(StringItem(text_after.to_string()));
+        let before_item: &dyn SkimItem = &StringItem(text_before.to_string());
+        let after_item: &dyn SkimItem = &StringItem(text_after.to_string());
 
         // Match both parts
         let before_result = self.before_engine.match_item(before_item)?;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -303,7 +303,7 @@ impl MatchResult {
 /// A matching engine that can match queries against items
 pub trait MatchEngine: Sync + Send + Display {
     /// Matches an item against the query, returning a result if matched
-    fn match_item(&self, item: Arc<dyn SkimItem>) -> Option<MatchResult>;
+    fn match_item(&self, item: &dyn SkimItem) -> Option<MatchResult>;
 }
 
 /// Factory for creating match engines

--- a/src/matcher.rs
+++ b/src/matcher.rs
@@ -176,7 +176,7 @@ impl Matcher {
                     processed.fetch_add(1, Ordering::Relaxed);
                     if stopped.load(Ordering::Relaxed) {
                         Some(Err("matcher killed"))
-                    } else if let Some(match_result) = matcher_engine.match_item(item.clone()) {
+                    } else if let Some(match_result) = matcher_engine.match_item(item.as_ref()) {
                         matched.fetch_add(1, Ordering::Relaxed);
                         // item is Arc but we get &Arc from iterator, so one clone is needed
                         Some(Ok(MatchedItem {


### PR DESCRIPTION
## Description of the changes

No reason to use Arc indirection here.  Here, we are cloning multiple times for no reason upon every matcher run.  This is slow because for each Clone and each Drop we increment and decrement the atomic ref count.

This seems like an inessential part of the skim API and we should just make this change.  See: https://docs.rs/skim/1.11.2/skim/trait.MatchEngine.html#tymethod.match_item