### PR TITLE
fix: undefined awk behaviour in bash integration

### DIFF
--- a/shell/key-bindings.bash
+++ b/shell/key-bindings.bash
@@ -57,11 +57,11 @@ if [[ $- =~ i ]]; then
 				last_hist=$(HISTTIMEFORMAT='' builtin history 1) awk -v last_hist="$last_hist" -v c_idx="$c_idx" -v c_reset="$c_reset" '
         BEGIN { HISTCMD = last_hist + 1; cmd = ""; idx = 0 }
         /^\t/ {
-          if (cmd != "" && !seen[cmd]++) printf "%s%d%s\t%s\0", c_idx, HISTCMD - idx, c_reset, cmd
+          if (cmd != "" && !seen[cmd]++) printf "%s%d%s\t%s%c", c_idx, HISTCMD - idx, c_reset, cmd, 0
           idx++; cmd = substr($0, 2); sub(/^[ *]/, "", cmd); next
         }
         { cmd = cmd "\n" $0 }
-        END { if (cmd != "" && !seen[cmd]++) printf "%s%d%s\t%s\0", c_idx, HISTCMD - idx, c_reset, cmd }
+        END { if (cmd != "" && !seen[cmd]++) printf "%s%d%s\t%s%c", c_idx, HISTCMD - idx, c_reset, cmd, 0 }
       ' |
 				SKIM_DEFAULT_OPTIONS="$SKIM_DEFAULT_OPTIONS -n2.. --bind=ctrl-r:toggle-sort $SKIM_CTRL_R_OPTS --no-multi --read0 $ansi_opt" $(__skimcmd) --query "$READLINE_LINE"
 		) || return


### PR DESCRIPTION
Replace awk `\0` escape sequences with `%c`[0] conversion which converts the int argument to a single byte character.

I encountered a bug with the CTRL-R history behaviour in bash, and tracked it down to these awk commands. I'm not sure what changed, but according to the documentation `\0` is undefined behaviour[1].

[0]: https://pubs.opengroup.org/onlinepubs/9799919799/basedefs/V1_chap05.html

[1]: https://pubs.opengroup.org/onlinepubs/9799919799/utilities/awk.html#tagtcjh_15

## Checklist

- [x] The title of my PR follows [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] I have updated the documentation (`README.md`, comments, `src/manpage.rs` and/or `src/options.rs` if applicable) 
- [ ] I have added unit tests
- [ ] I have added [integration tests](https://github.com/skim-rs/skim/tree/master/tests)
- [x] I have linked all related issues or PRs

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved bash history picker data handling for enhanced compatibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->