### PR TITLE
fix(tuikit): use write_all in Output::flush to avoid dropping bytes

### DIFF
--- a/skim-tuikit/src/output.rs
+++ b/skim-tuikit/src/output.rs
@@ -99,7 +99,7 @@ impl Output {
 
     /// Write to output stream and flush.
     pub fn flush(&mut self) {
-        let _ = self.stdout.write(&self.buffer);
+        let _ = self.stdout.write_all(&self.buffer);
         self.buffer.clear();
         let _ = self.stdout.flush();
     }


### PR DESCRIPTION
## Summary

`skim-tuikit`'s `Output::flush` calls `stdout.write(&self.buffer)`, which `io::Write::write` is explicitly allowed to satisfy with a short write — writing only some of the bytes and returning. The unwritten remainder is then discarded by the immediate `self.buffer.clear()` on the next line, so anything past the first short-write boundary is lost silently.

## Why it matters

This shows up whenever stdout is something with a small kernel buffer — PTYs default to ~1024 bytes on macOS/Linux — especially under load or with a slow consumer. The caller sees partial terminal output.

I hit this as a reproducible partial-first-render bug in the picker (vendoring `skim-tuikit` 0.6.6) when running inside a tmux PTY with ~a dozen items: sometimes all rows rendered, sometimes only the first ~7, with no pattern other than CPU load at startup. Instrumenting `flush` made the cause obvious:

```
flush: buf=8464 wrote=1024 dropped=7440
flush: buf=3382 wrote=1024 dropped=2358
flush: buf=6096 wrote=1024 dropped=5072
```

The kernel accepted the first ~1024 bytes, `write` returned, and the rest went to `clear()`.

## Fix

One-line change: `write` → `write_all`. `write_all` loops until the entire buffer is written (or errors), which is what `flush` is expected to do and matches the pattern used elsewhere in the file.

Note: the now-archived `skim-rs/tuikit` repo has the identical bug on `master` (v0.5.0). Since it's read-only, fixing only here on `feat/dynamic-header` where `skim-tuikit` 0.6.x lives.

## Test plan

- [x] `cargo check -p skim-tuikit` passes
- [x] Reproduce partial render in a tuikit consumer before/after — verified downstream in a picker: 15/15 reliable full renders after the fix vs intermittent truncation before

---

> _This was written by Claude Code on behalf of @max-sixty_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed an issue where buffered output could be incompletely written to the terminal, ensuring all data is properly flushed to the display.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->