### PR TITLE
fix(windows): raw_arg to avoid escape issue

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -90,9 +90,11 @@ fn shell_cmd(cmd: &str) -> Command {
     c
 }
 #[cfg(windows)]
+use std::os::windows::process::CommandExt;
+#[cfg(windows)]
 fn shell_cmd(cmd: &str) -> Command {
     let mut c = Command::new("cmd");
-    c.arg("/c").arg(cmd);
+    c.arg("/c").raw_arg(cmd);
     c
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -20,10 +20,12 @@
 //!     ).unwrap();
 //! ```
 
-#![warn(missing_docs)]
-#![warn(clippy::pedantic)]
-#![warn(clippy::incompatible_msrv)]
-#![allow(clippy::default_trait_access, clippy::struct_excessive_bools)]
+#![warn(clippy::pedantic, missing_docs, clippy::incompatible_msrv)]
+#![allow(
+    clippy::default_trait_access,
+    clippy::struct_excessive_bools,
+    clippy::collapsible_match
+)]
 
 #[macro_use]
 extern crate log;
@@ -90,9 +92,12 @@ fn shell_cmd(cmd: &str) -> Command {
     c
 }
 #[cfg(windows)]
-use std::os::windows::process::CommandExt;
-#[cfg(windows)]
 fn shell_cmd(cmd: &str) -> Command {
+    use std::os::windows::process::CommandExt as _;
+    // `cmd.exe` does not parse its command line using MSVC rules, so the default
+    // `Command::arg` escaping (quoting/backslash-escaping) corrupts shell
+    // metacharacters like `|`, `&`, `>` and embedded quotes. Pass the command
+    // string verbatim via `raw_arg` so cmd.exe sees exactly what the user wrote.
     let mut c = Command::new("cmd");
     c.arg("/c").raw_arg(cmd);
     c

--- a/src/popup/zellij.rs
+++ b/src/popup/zellij.rs
@@ -18,8 +18,7 @@ fn middle_coord(size: Size, var: &str) -> Size {
         Size::Percent(p) => Size::Percent(100u16.saturating_sub(p) / 2),
         Size::Fixed(cells) => Size::Fixed(
             std::env::var(var)
-                .map(|s| s.parse().unwrap_or(80))
-                .unwrap_or(80u16)
+                .map_or(80u16, |s| s.parse().unwrap_or(80))
                 .saturating_sub(cells)
                 / 2,
         ),
@@ -32,8 +31,7 @@ fn align_end_coord(size: Size, var: &str) -> Size {
         Size::Percent(p) => Size::Percent(100 - p),
         Size::Fixed(cols) => Size::Fixed(
             std::env::var(var)
-                .map(|s| s.parse().unwrap_or(80))
-                .unwrap_or(80u16)
+                .map_or(80u16, |s| s.parse().unwrap_or(80))
                 .saturating_sub(cols),
         ),
         Size::Neg(cells) => Size::Fixed(cells),

--- a/src/skim_item.rs
+++ b/src/skim_item.rs
@@ -93,6 +93,6 @@ impl Display for dyn SkimItem {
 }
 impl Debug for dyn SkimItem {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        f.write_fmt(format_args!("SkimItem {{ text: {} }}", self.text(),))
+        f.write_fmt(format_args!("SkimItem {{ text: {} }}", self.text()))
     }
 }


### PR DESCRIPTION
https://github.com/ibhagwan/fzf-lua/issues/2656#issuecomment-4286552939

## Checklist

- [ ] The title of my PR follows [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/)
- [ ] I have updated the documentation (`README.md`, comments, `src/manpage.rs` and/or `src/options.rs` if applicable) 
- [ ] I have added unit tests
- [ ] I have added [integration tests](https://github.com/skim-rs/skim/tree/master/tests)
- [ ] I have linked all related issues or PRs

## Description of the changes

_Note_: [codecov](https://codecov.io) runs on the PR on this repo, but feel free to ignore it.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved shell command execution on Windows for more consistent argument handling.

* **Refactor**
  * Simplified environment-variable parsing logic for size defaults to reduce complexity without changing behavior.
  * Consolidated lint settings and cleaned up minor debug formatting to tidy codebase.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->