### PR TITLE
fix: do not truncate display when longer than text

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -7,6 +7,11 @@ updates:
     commit-message:
       prefix: chore(deps)
       prefix-development: chore(dev-deps)
+    groups:
+      cargo-prod:
+        dependency-type: production
+      cargo-dev:
+        dependency-type: development
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:
@@ -16,3 +21,8 @@ updates:
       prefix-development: chore(dev-deps)
     exclude-paths:
       - .github/workflows/release.yml
+    groups:
+      gha-prod:
+        dependency-type: production
+      gha-dev:
+        dependency-type: development

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -23,6 +23,5 @@ updates:
       - .github/workflows/release.yml
     groups:
       gha-prod:
-        dependency-type: production
-      gha-dev:
-        dependency-type: development
+        patterns:
+          - "*"

--- a/.gitignore
+++ b/.gitignore
@@ -35,3 +35,5 @@ __pycache__/
 
 .envrc.local
 /public
+
+.codex

--- a/src/tui/item_renderer.rs
+++ b/src/tui/item_renderer.rs
@@ -7,6 +7,13 @@ use crate::tui::item_list::ItemList;
 use crate::tui::util::{char_display_width, clip_line_to_chars, wrap_text};
 use crate::{DisplayContext, MatchRange, item::MatchedItem, theme::ColorTheme};
 
+struct SubLineState {
+    is_current: bool,
+    is_selected: bool,
+    is_first: bool,
+    needs_ellipsis: bool,
+}
+
 /// Rendering parameters that are constant across all items in one render pass.
 pub(crate) struct ItemRenderer<'a> {
     pub theme: &'a ColorTheme,
@@ -65,7 +72,6 @@ impl<'a> ItemRenderer<'a> {
     /// `available_rows` is how many rows remain; rendering stops when exhausted.
     /// Returns the number of rows appended.
     #[allow(clippy::too_many_arguments)]
-    #[allow(clippy::too_many_lines)]
     pub fn render_item(
         &self,
         item: &MatchedItem,
@@ -77,30 +83,8 @@ impl<'a> ItemRenderer<'a> {
         out: &mut Vec<ListItem<'static>>,
     ) -> usize {
         let item_text = item.item.text();
-
-        let sub_lines: Vec<&str> = if let Some(sep) = self.multiline {
-            item_text.split(sep).collect()
-        } else {
-            vec![item_text.as_ref()]
-        };
-
-        // Match positions for hscroll on the first sub-line.
-        let (match_start_char, match_end_char) = match &item.matched_range {
-            Some(MatchRange::Chars(indices)) => {
-                if indices.is_empty() {
-                    (0, 0)
-                } else {
-                    (indices[0], indices[indices.len() - 1] + 1)
-                }
-            }
-            Some(MatchRange::ByteRange(start, end)) => {
-                let msc = item_text[..*start].chars().count();
-                let diff = item_text[*start..*end].chars().count();
-                (msc, msc + diff)
-            }
-            Some(MatchRange::CharRange(start, end)) => (*start, *end),
-            None => (0, 0),
-        };
+        let sub_lines = self.split_sub_lines(item_text.as_ref());
+        let (match_start_char, match_end_char) = Self::matched_range(item_text.as_ref(), item.matched_range.as_ref());
 
         let mut added = 0usize;
         // Collect rows for this item into a temporary buffer so we can reverse
@@ -113,178 +97,21 @@ impl<'a> ItemRenderer<'a> {
             }
 
             let is_first = sub_idx == skip_subs;
-
-            // Prefix: cursor icon + selection icon [+ score].
-            let mut prefix: Vec<Span<'static>> = Vec::with_capacity(3);
-            // When highlight_line is active for the current item, the line-level style fills the
-            // entire row with the current background. Reset the bg on prefix spans so the
-            // selector/marker columns are not highlighted.
-            let prefix_cursor_style = if self.highlight_line && is_current {
-                self.theme.cursor.bg(self.theme.cursor.bg.unwrap_or(Color::Reset))
-            } else {
-                self.theme.cursor
-            };
-            let prefix_selected_style = if self.highlight_line && is_current {
-                self.theme.selected.bg(self.theme.selected.bg.unwrap_or(Color::Reset))
-            } else {
-                self.theme.selected
-            };
-            prefix.push(Span::styled(
-                if is_first && is_current {
-                    self.selector_icon.to_owned()
-                } else {
-                    str::repeat(" ", self.selector_icon.chars().count())
-                },
-                prefix_cursor_style,
-            ));
-            prefix.push(Span::styled(
-                if is_first && self.multi_select && is_selected {
-                    self.multi_select_icon.to_owned()
-                } else {
-                    str::repeat(" ", self.multi_select_icon.chars().count())
-                },
-                prefix_selected_style,
-            ));
-            if self.show_score {
-                let score_str = format!("[{}] ", item.rank.score);
-                prefix.push(Span::styled(
-                    if is_first {
-                        score_str.clone()
-                    } else {
-                        str::repeat(" ", score_str.chars().count())
-                    },
-                    if is_current {
-                        self.theme.current
-                    } else {
-                        self.theme.normal
-                    },
-                ));
-            }
-            if self.show_index {
-                let index_str = format!("[{}] ", item.rank.index);
-                prefix.push(Span::styled(
-                    if is_first {
-                        index_str.clone()
-                    } else {
-                        str::repeat(" ", index_str.chars().count())
-                    },
-                    if is_current {
-                        self.theme.current
-                    } else {
-                        self.theme.normal
-                    },
-                ));
-            }
-
-            // Content spans for this sub-line.
-            let content_line: Line<'static> = if is_first {
-                let first_sub_char_len = sub_lines[0].chars().count();
-                let (shift, full_width, _, _) = self.calc_hscroll(sub_lines[0], match_start_char, match_end_char);
-
-                let matches = match &item.matched_range {
-                    Some(MatchRange::ByteRange(start, end)) => crate::Matches::ByteRange(*start, *end),
-                    Some(MatchRange::CharRange(start, end)) => crate::Matches::CharRange(*start, *end),
-                    Some(MatchRange::Chars(chars)) => crate::Matches::CharIndices(chars.clone()),
-                    None => crate::Matches::None,
-                };
-                let dl = item.item.display(DisplayContext {
-                    score: item.rank.score,
-                    matches,
-                    container_width: self.container_width,
-                    base_style: if is_current {
-                        self.theme.current
-                    } else {
-                        self.theme.normal
-                    },
-                    matched_style: if is_current {
-                        self.theme.current_match
-                    } else {
-                        self.theme.matched
-                    },
-                });
-
-                // Clip to first sub-line's chars only.
-                let mut line = clip_line_to_chars(dl, first_sub_char_len);
-                if !self.wrap {
-                    line = self.apply_hscroll(line, shift, full_width);
-                }
-                line.spans
-                    .into_iter()
-                    .map(|s| Span::styled(s.content.into_owned(), s.style))
-                    .collect()
-            } else {
-                let sub_str = sub_text.to_string();
-                let (shift, full_width, _, _) = self.calc_hscroll(&sub_str, 0, 0);
-                let base_style = if is_current {
-                    self.theme.current
-                } else {
-                    self.theme.normal
-                };
-                let raw: Line<'static> = Line::from(vec![Span::styled(sub_str, base_style)]);
-                if self.wrap {
-                    raw
-                } else {
-                    let scrolled = self.apply_hscroll(raw, shift, full_width);
-                    scrolled
-                        .spans
-                        .into_iter()
-                        .map(|s| Span::styled(s.content.into_owned(), s.style))
-                        .collect()
-                }
-            };
-
-            // Ellipsis for partially-visible sub-lines.
             let is_top_cutoff = is_first && skip_subs > 0;
             let is_bottom_cutoff = rows_used + added + 1 >= available_rows && sub_idx + 1 < sub_lines.len();
-            let needs_ellipsis = is_top_cutoff || is_bottom_cutoff;
-
-            let mut all_spans: Vec<Span<'static>> = prefix;
-            if needs_ellipsis {
-                let ell_width = usize::try_from(display_width(self.ellipsis)).unwrap();
-                let base_style = if is_current {
-                    self.theme.current
-                } else {
-                    self.theme.normal
-                };
-                let available = self.container_width.saturating_sub(ell_width);
-                let mut trimmed: Vec<Span<'static>> = Vec::new();
-                let mut used = 0usize;
-                'trim: for span in content_line.spans {
-                    let span_chars: Vec<char> = span.content.chars().collect();
-                    for (i, ch) in span_chars.iter().enumerate() {
-                        let w = char_display_width(*ch);
-                        if used + w > available {
-                            let partial: String = span_chars[..i].iter().collect();
-                            if !partial.is_empty() {
-                                trimmed.push(Span::styled(partial, span.style));
-                            }
-                            break 'trim;
-                        }
-                        used += w;
-                    }
-                    trimmed.push(Span::styled(span.content.into_owned(), span.style));
-                }
-                trimmed.push(Span::styled(self.ellipsis.to_owned(), base_style));
-                all_spans.extend(trimmed);
-            } else {
-                all_spans.extend(content_line.spans);
-            }
-
-            let list_item: ListItem<'static> = if self.wrap {
-                wrap_text(
-                    ratatui::text::Text::from(Line::from(all_spans)),
-                    self.container_width + self.selector_icon.chars().count() + self.multi_select_icon.chars().count(),
-                )
-                .into()
-            } else {
-                let mut line = Line::from(all_spans);
-                // When highlight_line is enabled, set the line's style to the current theme
-                // so ratatui fills the entire row width with the current background color.
-                if self.highlight_line && is_current {
-                    line = line.style(self.theme.current);
-                }
-                line.into()
-            };
+            let list_item = self.render_sub_line(
+                item,
+                sub_text,
+                &sub_lines,
+                &SubLineState {
+                    is_current,
+                    is_selected,
+                    is_first,
+                    needs_ellipsis: is_top_cutoff || is_bottom_cutoff,
+                },
+                match_start_char,
+                match_end_char,
+            );
 
             item_rows.push(list_item);
             added += 1;
@@ -296,6 +123,247 @@ impl<'a> ItemRenderer<'a> {
         out.extend(item_rows);
 
         added
+    }
+
+    fn split_sub_lines<'b>(&self, item_text: &'b str) -> Vec<&'b str> {
+        if let Some(sep) = self.multiline {
+            item_text.split(sep).collect()
+        } else {
+            vec![item_text]
+        }
+    }
+
+    fn matched_range(item_text: &str, matched_range: Option<&MatchRange>) -> (usize, usize) {
+        match matched_range {
+            Some(MatchRange::Chars(indices)) => {
+                if indices.is_empty() {
+                    (0, 0)
+                } else {
+                    (indices[0], indices[indices.len() - 1] + 1)
+                }
+            }
+            Some(MatchRange::ByteRange(start, end)) => {
+                let start_char = item_text[..*start].chars().count();
+                let len = item_text[*start..*end].chars().count();
+                (start_char, start_char + len)
+            }
+            Some(MatchRange::CharRange(start, end)) => (*start, *end),
+            None => (0, 0),
+        }
+    }
+
+    fn render_sub_line(
+        &self,
+        item: &MatchedItem,
+        sub_text: &str,
+        sub_lines: &[&str],
+        state: &SubLineState,
+        match_start_char: usize,
+        match_end_char: usize,
+    ) -> ListItem<'static> {
+        let mut all_spans = self.prefix_spans(item, state);
+        let content_line = self.content_line(item, sub_text, sub_lines, state, match_start_char, match_end_char);
+
+        if state.needs_ellipsis {
+            all_spans.extend(self.trim_with_ellipsis(content_line, state.is_current));
+        } else {
+            all_spans.extend(content_line.spans);
+        }
+
+        self.list_item_from_spans(all_spans, state.is_current)
+    }
+
+    fn prefix_spans(&self, item: &MatchedItem, state: &SubLineState) -> Vec<Span<'static>> {
+        let mut prefix: Vec<Span<'static>> = Vec::with_capacity(4);
+        // When highlight_line is active for the current item, the line-level style fills the
+        // entire row with the current background. Reset the bg on prefix spans so the
+        // selector/marker columns are not highlighted.
+        let prefix_cursor_style = if self.highlight_line && state.is_current {
+            self.theme.cursor.bg(self.theme.cursor.bg.unwrap_or(Color::Reset))
+        } else {
+            self.theme.cursor
+        };
+        let prefix_selected_style = if self.highlight_line && state.is_current {
+            self.theme.selected.bg(self.theme.selected.bg.unwrap_or(Color::Reset))
+        } else {
+            self.theme.selected
+        };
+
+        prefix.push(Span::styled(
+            if state.is_first && state.is_current {
+                self.selector_icon.to_owned()
+            } else {
+                str::repeat(" ", self.selector_icon.chars().count())
+            },
+            prefix_cursor_style,
+        ));
+        prefix.push(Span::styled(
+            if state.is_first && self.multi_select && state.is_selected {
+                self.multi_select_icon.to_owned()
+            } else {
+                str::repeat(" ", self.multi_select_icon.chars().count())
+            },
+            prefix_selected_style,
+        ));
+        if self.show_score {
+            self.push_first_line_field(&mut prefix, state, item.rank.score);
+        }
+        if self.show_index {
+            self.push_first_line_field(&mut prefix, state, item.rank.index);
+        }
+
+        prefix
+    }
+
+    fn push_first_line_field(
+        &self,
+        prefix: &mut Vec<Span<'static>>,
+        state: &SubLineState,
+        value: impl std::fmt::Display,
+    ) {
+        let value = format!("[{value}] ");
+        prefix.push(Span::styled(
+            if state.is_first {
+                value.clone()
+            } else {
+                str::repeat(" ", value.chars().count())
+            },
+            self.base_style(state.is_current),
+        ));
+    }
+
+    fn content_line(
+        &self,
+        item: &MatchedItem,
+        sub_text: &str,
+        sub_lines: &[&str],
+        state: &SubLineState,
+        match_start_char: usize,
+        match_end_char: usize,
+    ) -> Line<'static> {
+        if state.is_first {
+            self.first_sub_line_content(item, sub_lines[0], state.is_current, match_start_char, match_end_char)
+        } else {
+            self.continuation_sub_line_content(sub_text, state.is_current)
+        }
+    }
+
+    fn first_sub_line_content(
+        &self,
+        item: &MatchedItem,
+        first_sub_line: &str,
+        is_current: bool,
+        match_start_char: usize,
+        match_end_char: usize,
+    ) -> Line<'static> {
+        let first_sub_char_len = first_sub_line.chars().count();
+        let dl = item.item.display(DisplayContext {
+            score: item.rank.score,
+            matches: Self::display_matches(item.matched_range.as_ref()),
+            container_width: self.container_width,
+            base_style: self.base_style(is_current),
+            matched_style: if is_current {
+                self.theme.current_match
+            } else {
+                self.theme.matched
+            },
+        });
+
+        // In multiline mode the first rendered line must be clipped to the first text sub-line.
+        // Without multiline, custom display text may legitimately be longer than item.text().
+        let mut line = if self.multiline.is_some() {
+            clip_line_to_chars(dl, first_sub_char_len)
+        } else {
+            dl
+        };
+        if !self.wrap {
+            let (shift, full_width, _, _) = if self.multiline.is_some() {
+                self.calc_hscroll(first_sub_line, match_start_char, match_end_char)
+            } else {
+                self.calc_line_hscroll(&line, first_sub_line, match_start_char, match_end_char)
+            };
+            line = self.apply_hscroll(line, shift, full_width);
+        }
+        Self::into_static_line(line)
+    }
+
+    fn continuation_sub_line_content(&self, sub_text: &str, is_current: bool) -> Line<'static> {
+        let sub_str = sub_text.to_string();
+        let (shift, full_width, _, _) = self.calc_hscroll(&sub_str, 0, 0);
+        let raw: Line<'static> = Line::from(vec![Span::styled(sub_str, self.base_style(is_current))]);
+        if self.wrap {
+            raw
+        } else {
+            let scrolled = self.apply_hscroll(raw, shift, full_width);
+            Self::into_static_line(scrolled)
+        }
+    }
+
+    fn display_matches(matched_range: Option<&MatchRange>) -> crate::Matches {
+        match matched_range {
+            Some(MatchRange::ByteRange(start, end)) => crate::Matches::ByteRange(*start, *end),
+            Some(MatchRange::CharRange(start, end)) => crate::Matches::CharRange(*start, *end),
+            Some(MatchRange::Chars(chars)) => crate::Matches::CharIndices(chars.clone()),
+            None => crate::Matches::None,
+        }
+    }
+
+    fn trim_with_ellipsis(&self, content_line: Line<'static>, is_current: bool) -> Vec<Span<'static>> {
+        let ell_width = usize::try_from(display_width(self.ellipsis)).unwrap();
+        let available = self.container_width.saturating_sub(ell_width);
+        let mut trimmed: Vec<Span<'static>> = Vec::new();
+        let mut used = 0usize;
+
+        'trim: for span in content_line.spans {
+            let span_chars: Vec<char> = span.content.chars().collect();
+            for (i, ch) in span_chars.iter().enumerate() {
+                let w = char_display_width(*ch);
+                if used + w > available {
+                    let partial: String = span_chars[..i].iter().collect();
+                    if !partial.is_empty() {
+                        trimmed.push(Span::styled(partial, span.style));
+                    }
+                    break 'trim;
+                }
+                used += w;
+            }
+            trimmed.push(Span::styled(span.content.into_owned(), span.style));
+        }
+        trimmed.push(Span::styled(self.ellipsis.to_owned(), self.base_style(is_current)));
+        trimmed
+    }
+
+    fn list_item_from_spans(&self, spans: Vec<Span<'static>>, is_current: bool) -> ListItem<'static> {
+        if self.wrap {
+            wrap_text(
+                ratatui::text::Text::from(Line::from(spans)),
+                self.container_width + self.selector_icon.chars().count() + self.multi_select_icon.chars().count(),
+            )
+            .into()
+        } else {
+            let mut line = Line::from(spans);
+            // When highlight_line is enabled, set the line's style to the current theme
+            // so ratatui fills the entire row width with the current background color.
+            if self.highlight_line && is_current {
+                line = line.style(self.theme.current);
+            }
+            line.into()
+        }
+    }
+
+    fn base_style(&self, is_current: bool) -> ratatui::style::Style {
+        if is_current {
+            self.theme.current
+        } else {
+            self.theme.normal
+        }
+    }
+
+    fn into_static_line(line: Line<'_>) -> Line<'static> {
+        line.spans
+            .into_iter()
+            .map(|span| Span::styled(span.content.into_owned(), span.style))
+            .collect()
     }
 
     // ── hscroll helpers ──────────────────────────────────────────────────────
@@ -310,14 +378,28 @@ impl<'a> ItemRenderer<'a> {
     }
 
     fn calc_hscroll(&self, text: &str, match_start_char: usize, match_end_char: usize) -> (usize, usize, bool, bool) {
-        let full_width = text.chars().fold(0usize, |acc, ch| {
-            if ch == '\t' {
-                acc + self.tabstop - (acc % self.tabstop)
-            } else {
-                acc + char_display_width(ch)
-            }
-        });
+        let full_width = self.text_display_width(text);
 
+        self.calc_hscroll_for_width(text, match_start_char, match_end_char, full_width)
+    }
+
+    fn calc_line_hscroll(
+        &self,
+        line: &Line<'_>,
+        text: &str,
+        match_start_char: usize,
+        match_end_char: usize,
+    ) -> (usize, usize, bool, bool) {
+        self.calc_hscroll_for_width(text, match_start_char, match_end_char, self.line_display_width(line))
+    }
+
+    fn calc_hscroll_for_width(
+        &self,
+        text: &str,
+        match_start_char: usize,
+        match_end_char: usize,
+        full_width: usize,
+    ) -> (usize, usize, bool, bool) {
         let ell_w = usize::try_from(display_width(self.ellipsis)).unwrap();
         let available_width = if self.container_width >= ell_w {
             self.container_width
@@ -382,6 +464,26 @@ impl<'a> ItemRenderer<'a> {
         };
 
         (shift, full_width, shift > 0, shift + available_width < full_width)
+    }
+
+    fn text_display_width(&self, text: &str) -> usize {
+        text.chars().fold(0usize, |width, ch| self.add_char_width(width, ch))
+    }
+
+    fn line_display_width(&self, line: &Line<'_>) -> usize {
+        line.spans.iter().fold(0usize, |width, span| {
+            span.content
+                .chars()
+                .fold(width, |span_width, ch| self.add_char_width(span_width, ch))
+        })
+    }
+
+    fn add_char_width(&self, width: usize, ch: char) -> usize {
+        if ch == '\t' {
+            width + self.tabstop - (width % self.tabstop)
+        } else {
+            width + char_display_width(ch)
+        }
     }
 
     fn apply_hscroll<'b>(&'b self, line: Line<'b>, shift: usize, full_width: usize) -> Line<'b> {
@@ -473,5 +575,193 @@ impl<'a> ItemRenderer<'a> {
             }
         }
         result
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::borrow::Cow;
+    use std::sync::Arc;
+
+    use ratatui::style::Style;
+
+    use super::*;
+    use crate::item::RankBuilder;
+    use crate::{Rank, SkimItem};
+
+    fn renderer(theme: &ColorTheme) -> ItemRenderer<'_> {
+        ItemRenderer {
+            theme,
+            selector_icon: ">",
+            multi_select_icon: "*",
+            ellipsis: "..",
+            container_width: 6,
+            wrap: false,
+            multiline: None,
+            show_score: false,
+            show_index: false,
+            multi_select: false,
+            tabstop: 4,
+            no_hscroll: false,
+            keep_right: false,
+            manual_hscroll: 0,
+            skip_to_pattern: None,
+            reverse_sub_lines: false,
+            highlight_line: false,
+        }
+    }
+
+    fn matched_item(text: &str, matched_range: Option<MatchRange>) -> MatchedItem {
+        MatchedItem::new(
+            Arc::new(text.to_owned()) as Arc<dyn SkimItem>,
+            Rank::default(),
+            matched_range,
+            &RankBuilder::default(),
+        )
+    }
+
+    fn line_text(line: &Line<'_>) -> String {
+        line.spans.iter().map(|span| span.content.as_ref()).collect()
+    }
+
+    fn spans_text(spans: &[Span<'_>]) -> String {
+        spans.iter().map(|span| span.content.as_ref()).collect()
+    }
+
+    struct DisplayLongerThanText;
+
+    impl SkimItem for DisplayLongerThanText {
+        fn text(&self) -> Cow<'_, str> {
+            Cow::Borrowed("ab")
+        }
+
+        fn display(&self, _context: DisplayContext) -> Line<'_> {
+            Line::from("abcdefghi")
+        }
+    }
+
+    #[test]
+    fn split_sub_lines_uses_configured_separator() {
+        let theme = ColorTheme::default();
+        let mut renderer = renderer(&theme);
+
+        assert_eq!(renderer.split_sub_lines("alpha|beta"), vec!["alpha|beta"]);
+
+        renderer.multiline = Some("|");
+        assert_eq!(
+            renderer.split_sub_lines("alpha|beta|gamma"),
+            vec!["alpha", "beta", "gamma"]
+        );
+    }
+
+    #[test]
+    fn matched_range_as_char_range_normalizes_supported_ranges() {
+        assert_eq!(
+            ItemRenderer::matched_range("aébc", Some(&MatchRange::ByteRange(1, 3))),
+            (1, 2)
+        );
+        assert_eq!(
+            ItemRenderer::matched_range("abcdef", Some(&MatchRange::Chars(vec![1, 3, 4]))),
+            (1, 5)
+        );
+        assert_eq!(
+            ItemRenderer::matched_range("abcdef", Some(&MatchRange::Chars(vec![]))),
+            (0, 0)
+        );
+        assert_eq!(
+            ItemRenderer::matched_range("abcdef", Some(&MatchRange::CharRange(2, 4))),
+            (2, 4)
+        );
+        assert_eq!(ItemRenderer::matched_range("abcdef", None), (0, 0));
+    }
+
+    #[test]
+    fn display_matches_preserves_original_match_kind() {
+        assert!(matches!(
+            ItemRenderer::display_matches(Some(&MatchRange::ByteRange(1, 3))),
+            crate::Matches::ByteRange(1, 3)
+        ));
+        assert!(matches!(
+            ItemRenderer::display_matches(Some(&MatchRange::CharRange(2, 4))),
+            crate::Matches::CharRange(2, 4)
+        ));
+        assert!(matches!(
+            ItemRenderer::display_matches(Some(&MatchRange::Chars(vec![0, 2]))),
+            crate::Matches::CharIndices(indices) if indices == vec![0, 2]
+        ));
+        assert!(matches!(ItemRenderer::display_matches(None), crate::Matches::None));
+    }
+
+    #[test]
+    fn prefix_spans_uses_state_for_icons_and_first_line_fields() {
+        let theme = ColorTheme::default();
+        let mut renderer = renderer(&theme);
+        renderer.multi_select = true;
+        renderer.show_score = true;
+        renderer.show_index = true;
+
+        let mut item = matched_item("alpha", None);
+        item.rank.score = 42;
+        item.rank.index = 7;
+
+        let current_selected = SubLineState {
+            is_current: true,
+            is_selected: true,
+            is_first: true,
+            needs_ellipsis: false,
+        };
+        let continuation = SubLineState {
+            is_current: true,
+            is_selected: true,
+            is_first: false,
+            needs_ellipsis: false,
+        };
+
+        assert_eq!(
+            spans_text(&renderer.prefix_spans(&item, &current_selected)),
+            ">*[42] [7] "
+        );
+        assert_eq!(spans_text(&renderer.prefix_spans(&item, &continuation)), "           ");
+    }
+
+    #[test]
+    fn trim_with_ellipsis_reserves_space_for_marker() {
+        let theme = ColorTheme::default();
+        let renderer = renderer(&theme);
+        let line = Line::from(vec![
+            Span::styled("abc", Style::default()),
+            Span::styled("def", Style::default()),
+        ]);
+
+        let trimmed = renderer.trim_with_ellipsis(line, false);
+
+        assert_eq!(spans_text(&trimmed), "abcd..");
+    }
+
+    #[test]
+    fn continuation_sub_line_content_applies_hscroll() {
+        let theme = ColorTheme::default();
+        let mut renderer = renderer(&theme);
+        renderer.manual_hscroll = 2;
+
+        let line = renderer.continuation_sub_line_content("abcdefgh", false);
+
+        assert_eq!(line_text(&line), "..cdef");
+    }
+
+    #[test]
+    fn first_sub_line_content_keeps_display_longer_than_text() {
+        let theme = ColorTheme::default();
+        let renderer = renderer(&theme);
+        let item = MatchedItem::new(
+            Arc::new(DisplayLongerThanText) as Arc<dyn SkimItem>,
+            Rank::default(),
+            None,
+            &RankBuilder::default(),
+        );
+
+        let line = renderer.first_sub_line_content(&item, "ab", false, 0, 0);
+
+        assert_eq!(line_text(&line), "abcd..");
     }
 }

--- a/src/tui/item_renderer.rs
+++ b/src/tui/item_renderer.rs
@@ -103,7 +103,6 @@ impl<'a> ItemRenderer<'a> {
             let list_item = self.render_sub_line(
                 item,
                 sub_text,
-                &sub_lines,
                 &SubLineState {
                     is_current,
                     is_selected,
@@ -158,13 +157,12 @@ impl<'a> ItemRenderer<'a> {
         &self,
         item: &MatchedItem,
         sub_text: &str,
-        sub_lines: &[&str],
         state: &SubLineState,
         match_start_char: usize,
         match_end_char: usize,
     ) -> ListItem<'static> {
         let mut all_spans = self.prefix_spans(item, state);
-        let content_line = self.content_line(item, sub_text, sub_lines, state, match_start_char, match_end_char);
+        let content_line = self.content_line(item, sub_text, state, match_start_char, match_end_char);
 
         if state.needs_ellipsis {
             all_spans.extend(self.trim_with_ellipsis(content_line, state.is_current));
@@ -238,13 +236,12 @@ impl<'a> ItemRenderer<'a> {
         &self,
         item: &MatchedItem,
         sub_text: &str,
-        sub_lines: &[&str],
         state: &SubLineState,
         match_start_char: usize,
         match_end_char: usize,
     ) -> Line<'static> {
-        if state.is_first_sub_line {
-            self.first_sub_line_content(item, sub_lines[0], state.is_current, match_start_char, match_end_char)
+        if state.is_first && state.is_first_sub_line {
+            self.first_sub_line_content(item, sub_text, state.is_current, match_start_char, match_end_char)
         } else {
             self.continuation_sub_line_content(sub_text, state.is_current)
         }
@@ -295,8 +292,7 @@ impl<'a> ItemRenderer<'a> {
         if self.wrap {
             raw
         } else {
-            let text = raw.spans.first().map_or("", |span| span.content.as_ref());
-            let (shift, full_width, _, _) = self.calc_hscroll(text, 0, 0);
+            let (shift, full_width, _, _) = self.calc_hscroll(sub_text, 0, 0);
             let scrolled = self.apply_hscroll(raw, shift, full_width);
             Self::into_static_line(scrolled)
         }

--- a/src/tui/item_renderer.rs
+++ b/src/tui/item_renderer.rs
@@ -8,9 +8,13 @@ use crate::tui::util::{char_display_width, clip_line_to_chars, wrap_text};
 use crate::{DisplayContext, MatchRange, item::MatchedItem, theme::ColorTheme};
 
 struct SubLineState {
+    /// Current item
     is_current: bool,
+    /// Selected (in multi-select)
     is_selected: bool,
+    /// First item on the screen
     is_first: bool,
+    /// First line of the item
     is_first_sub_line: bool,
     needs_ellipsis: bool,
 }
@@ -783,5 +787,7 @@ mod tests {
 
         assert_eq!(added, 2);
         assert_eq!(rendered_row_text(out.remove(0), 8), "  second");
+        assert_eq!(rendered_row_text(out.remove(0), 8), "  third ");
+        assert!(out.is_empty());
     }
 }

--- a/src/tui/item_renderer.rs
+++ b/src/tui/item_renderer.rs
@@ -11,6 +11,7 @@ struct SubLineState {
     is_current: bool,
     is_selected: bool,
     is_first: bool,
+    is_first_sub_line: bool,
     needs_ellipsis: bool,
 }
 
@@ -107,6 +108,7 @@ impl<'a> ItemRenderer<'a> {
                     is_current,
                     is_selected,
                     is_first,
+                    is_first_sub_line: sub_idx == 0,
                     needs_ellipsis: is_top_cutoff || is_bottom_cutoff,
                 },
                 match_start_char,
@@ -241,7 +243,7 @@ impl<'a> ItemRenderer<'a> {
         match_start_char: usize,
         match_end_char: usize,
     ) -> Line<'static> {
-        if state.is_first {
+        if state.is_first_sub_line {
             self.first_sub_line_content(item, sub_lines[0], state.is_current, match_start_char, match_end_char)
         } else {
             self.continuation_sub_line_content(sub_text, state.is_current)
@@ -289,11 +291,12 @@ impl<'a> ItemRenderer<'a> {
 
     fn continuation_sub_line_content(&self, sub_text: &str, is_current: bool) -> Line<'static> {
         let sub_str = sub_text.to_string();
-        let (shift, full_width, _, _) = self.calc_hscroll(&sub_str, 0, 0);
         let raw: Line<'static> = Line::from(vec![Span::styled(sub_str, self.base_style(is_current))]);
         if self.wrap {
             raw
         } else {
+            let text = raw.spans.first().map_or("", |span| span.content.as_ref());
+            let (shift, full_width, _, _) = self.calc_hscroll(text, 0, 0);
             let scrolled = self.apply_hscroll(raw, shift, full_width);
             Self::into_static_line(scrolled)
         }
@@ -435,11 +438,7 @@ impl<'a> ItemRenderer<'a> {
                     found_end = true;
                     break;
                 }
-                if ch == '\t' {
-                    current_width += self.tabstop - (current_width % self.tabstop);
-                } else {
-                    current_width += char_display_width(ch);
-                }
+                current_width = self.add_char_width(current_width, ch);
             }
             if found_start && !found_end {
                 match_end_width = current_width;
@@ -546,15 +545,10 @@ impl<'a> ItemRenderer<'a> {
         let mut char_index = 0;
         for span in &line.spans {
             for ch in span.content.chars() {
-                let ch_width = if ch == '\t' {
-                    self.tabstop - (current_width % self.tabstop)
-                } else {
-                    char_display_width(ch)
-                };
                 if current_width >= target_width {
                     return char_index;
                 }
-                current_width += ch_width;
+                current_width = self.add_char_width(current_width, ch);
                 char_index += 1;
             }
         }
@@ -566,12 +560,13 @@ impl<'a> ItemRenderer<'a> {
         let mut current_width = start_width;
         for ch in text.chars() {
             if ch == '\t' {
-                let tab_width = self.tabstop - (current_width % self.tabstop);
+                let next_width = self.add_char_width(current_width, ch);
+                let tab_width = next_width - current_width;
                 result.push_str(&" ".repeat(tab_width));
-                current_width += tab_width;
+                current_width = next_width;
             } else {
                 result.push(ch);
-                current_width += char_display_width(ch);
+                current_width = self.add_char_width(current_width, ch);
             }
         }
         result
@@ -583,7 +578,10 @@ mod tests {
     use std::borrow::Cow;
     use std::sync::Arc;
 
+    use ratatui::buffer::Buffer;
+    use ratatui::layout::Rect;
     use ratatui::style::Style;
+    use ratatui::widgets::{List, Widget};
 
     use super::*;
     use crate::item::RankBuilder;
@@ -626,6 +624,14 @@ mod tests {
 
     fn spans_text(spans: &[Span<'_>]) -> String {
         spans.iter().map(|span| span.content.as_ref()).collect()
+    }
+
+    fn rendered_row_text(item: ListItem<'static>, width: u16) -> String {
+        let mut buf = Buffer::empty(Rect::new(0, 0, width, 1));
+        List::new(vec![item]).render(buf.area, &mut buf);
+        (0..width)
+            .map(|x| buf.cell((x, 0)).expect("cell should be inside buffer").symbol())
+            .collect::<String>()
     }
 
     struct DisplayLongerThanText;
@@ -708,12 +714,14 @@ mod tests {
             is_current: true,
             is_selected: true,
             is_first: true,
+            is_first_sub_line: true,
             needs_ellipsis: false,
         };
         let continuation = SubLineState {
             is_current: true,
             is_selected: true,
             is_first: false,
+            is_first_sub_line: false,
             needs_ellipsis: false,
         };
 
@@ -763,5 +771,21 @@ mod tests {
         let line = renderer.first_sub_line_content(&item, "ab", false, 0, 0);
 
         assert_eq!(line_text(&line), "abcd..");
+    }
+
+    #[test]
+    fn render_item_with_multiline_skip_starts_at_skipped_sub_line() {
+        let theme = ColorTheme::default();
+        let mut renderer = renderer(&theme);
+        renderer.multiline = Some("|");
+        renderer.container_width = 20;
+
+        let item = matched_item("first|second|third", None);
+        let mut out = Vec::new();
+
+        let added = renderer.render_item(&item, false, false, 1, 10, 0, &mut out);
+
+        assert_eq!(added, 2);
+        assert_eq!(rendered_row_text(out.remove(0), 8), "  second");
     }
 }


### PR DESCRIPTION
## Checklist

- [x] The title of my PR follows [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] I have updated the documentation (`README.md`, comments, `src/manpage.rs` and/or `src/options.rs` if applicable) 
- [x] I have added unit tests
- [x] I have added [integration tests](https://github.com/skim-rs/skim/tree/master/tests)
- [x] I have linked all related issues or PRs

## Description of the changes

_Note_: [codecov](https://codecov.io) runs on the PR on this repo, but feel free to ignore it.


closes #1063 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Improved terminal UI rendering: more reliable multiline handling, consistent horizontal scrolling, clearer per-row styling, and better ellipsis trimming for clipped lines.

* **Tests**
  * Added thorough unit tests covering rendering, scrolling, clipping, match normalization, and multiline behaviors.

* **Chores**
  * Organized dependency updates into separate production vs. development groups and added a wildcard group for GitHub Actions; added .codex to ignored paths.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->