### PR TITLE
fix: re-enable `--no-mouse`

### DIFF
--- a/src/skim.rs
+++ b/src/skim.rs
@@ -121,7 +121,11 @@ impl Skim {
     ///
     /// Returns an error if the TUI backend cannot be initialized.
     pub fn init_tui(&mut self) -> Result<()> {
-        self.tui = Some(Tui::new_with_height(self.height)?);
+        let mut tui = Tui::new_with_height(self.height)?;
+        if self.app.options.no_mouse {
+            tui.disable_mouse();
+        }
+        self.tui = Some(tui);
         Ok(())
     }
 }

--- a/src/tui/backend.rs
+++ b/src/tui/backend.rs
@@ -40,6 +40,7 @@ where
     pub cancellation_token: CancellationToken,
     /// Whether running in fullscreen mode
     pub is_fullscreen: bool,
+    enable_mouse: bool,
 }
 
 impl Tui {
@@ -51,6 +52,12 @@ impl Tui {
     pub fn new_with_height(height: Size) -> Result<Self> {
         let backend = CrosstermBackend::new(std::io::BufWriter::new(std::io::stderr()));
         Self::new_with_height_and_backend(backend, height)
+    }
+    /// Disable mouse handling
+    /// Needs to be called before enter
+    pub fn disable_mouse(&mut self) -> &mut Self {
+        self.enable_mouse = false;
+        self
     }
 }
 
@@ -107,6 +114,7 @@ where
             tick_rate: f64::from(TICK_RATE),
             cancellation_token: CancellationToken::default(),
             is_fullscreen: lines.is_none(),
+            enable_mouse: true,
         })
     }
 
@@ -121,7 +129,11 @@ where
         // performs terminal cleanup instead of killing the process abruptly.
         #[cfg(windows)]
         super::windows::install_ctrl_c_handler()?;
-        crossterm::execute!(std::io::stderr(), EnableMouseCapture, EnableBracketedPaste)?;
+
+        crossterm::execute!(std::io::stderr(), EnableBracketedPaste)?;
+        if self.enable_mouse {
+            crossterm::execute!(std::io::stderr(), EnableMouseCapture)?;
+        }
         if self.is_fullscreen {
             crossterm::execute!(std::io::stderr(), EnterAlternateScreen, cursor::Hide)?;
         }

--- a/src/tui/backend.rs
+++ b/src/tui/backend.rs
@@ -53,8 +53,8 @@ impl Tui {
         let backend = CrosstermBackend::new(std::io::BufWriter::new(std::io::stderr()));
         Self::new_with_height_and_backend(backend, height)
     }
-    /// Disable mouse handling
-    /// Needs to be called before enter
+    /// Disable mouse handling.
+    /// Needs to be called before enter.
     pub fn disable_mouse(&mut self) -> &mut Self {
         self.enable_mouse = false;
         self


### PR DESCRIPTION
closes #1072

## Checklist

- [x] The title of my PR follows [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] I have updated the documentation (`README.md`, comments, `src/manpage.rs` and/or `src/options.rs` if applicable) 
- [x] I have added unit tests
- [x] I have added [integration tests](https://github.com/skim-rs/skim/tree/master/tests)
- [x] I have linked all related issues or PRs

## Description of the changes

_Note_: [codecov](https://codecov.io) runs on the PR on this repo, but feel free to ignore it.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Users can disable mouse input handling in the terminal interface with the --no-mouse option; when disabled, mouse capture is not activated.
  * Bracketed paste support remains enabled regardless of mouse capture, improving paste handling even when mouse input is turned off.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/skim-rs/skim/pull/1074?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->