### PR TITLE
fix(arinae): treat brackets and parens as word separators (#1075)

### DIFF
--- a/src/fuzzy_matcher/arinae/constants.rs
+++ b/src/fuzzy_matcher/arinae/constants.rs
@@ -51,5 +51,16 @@ pub(super) const SEPARATOR_TABLE: [Score; 128] = {
     t[b'/' as usize] = 16; // forward slash (path separator — higher bonus)
     t[b'\\' as usize] = 16; // backslash (Windows path separator — higher bonus)
     t[b'_' as usize] = 12; // underscore / snake_case
+    // Brackets / parens / braces delimit tokens just like spaces do, so a
+    // match immediately inside them should not be penalised relative to a
+    // match after whitespace. Without these entries `[paste] some paste`
+    // queried with `paste` scored the second occurrence higher than the
+    // first and highlighted the wrong one.
+    t[b'[' as usize] = 16;
+    t[b']' as usize] = 16;
+    t[b'(' as usize] = 16;
+    t[b')' as usize] = 16;
+    t[b'{' as usize] = 16;
+    t[b'}' as usize] = 16;
     t
 };

--- a/src/fuzzy_matcher/arinae/tests.rs
+++ b/src/fuzzy_matcher/arinae/tests.rs
@@ -410,3 +410,29 @@ fn no_use_last_match_prefers_first_occurrence() {
     let (_, got) = m.fuzzy_indices("man/man1/sk.1", "man").expect("should match");
     assert_eq!(got, vec![0, 1, 2], "expected second 'man' (indices 0,1,2), got {got:?}");
 }
+
+#[test]
+fn first_match_inside_brackets_is_highlighted() {
+    // Regression test for skim-rs/skim#1075. `[paste] some paste` queried with
+    // `paste` should highlight the first occurrence (inside the brackets), not
+    // the second. Before treating brackets as word separators the second
+    // occurrence scored higher because it followed a space.
+    let m = ArinaeMatcher::default();
+    let (_, got) = m.fuzzy_indices("[paste] some paste", "paste").expect("should match");
+    assert_eq!(
+        got,
+        vec![1, 2, 3, 4, 5],
+        "expected first 'paste' inside brackets, got {got:?}"
+    );
+
+    // Same expectation for the other bracket and paren variants now treated
+    // as separators.
+    for choice in ["(paste) some paste", "{paste} some paste"] {
+        let (_, got) = m.fuzzy_indices(choice, "paste").expect("should match");
+        assert_eq!(
+            got,
+            vec![1, 2, 3, 4, 5],
+            "expected first 'paste' for {choice:?}, got {got:?}"
+        );
+    }
+}


### PR DESCRIPTION
## Checklist

- [x] The title of my PR follows [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/)
- [ ] I have updated the documentation (`README.md`, comments, `src/manpage.rs` and/or `src/options.rs` if applicable) 
- [x] I have added unit tests
- [ ] I have added [integration tests](https://github.com/skim-rs/skim/tree/master/tests)
- [x] I have linked all related issues or PRs

## Description of the changes

Closes #1075.

`[paste] some paste` queried with `paste` highlights the second `paste` because the `[` preceding the first occurrence is not in `SEPARATOR_TABLE`, so it scores no separator bonus, while the space before the second `paste` does. Brackets, parens and braces normally delimit tokens just like whitespace, so a match immediately inside them should not be penalised relative to a match after a space.

Adds `[`, `]`, `(`, `)`, `{`, `}` to `SEPARATOR_TABLE` with the same bonus as space. The first occurrence now wins ties as the existing `no_use_last_match_prefers_first_occurrence` test already expects.

Regression test `first_match_inside_brackets_is_highlighted` covers brackets, parens and braces.

_Note_: [codecov](https://codecov.io) runs on the PR on this repo, but feel free to ignore it.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Improved fuzzy matching for text containing brackets, parentheses, and braces by treating them as word separators for consistent match highlighting.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/skim-rs/skim/pull/1076?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->