### PR TITLE
fix: multiline popup cmd misread

### DIFF
--- a/src/options.rs
+++ b/src/options.rs
@@ -10,6 +10,7 @@ use crossterm::event::{KeyCode, KeyEvent, KeyModifiers};
 use derive_builder::Builder;
 use regex::Regex;
 
+use crate::SKIM_DEFAULT_COMMAND;
 use crate::binds::KeyMap;
 use crate::item::RankCriteria;
 use crate::prelude::SkimItemReader;
@@ -1337,7 +1338,11 @@ impl SkimOptions {
             args.push(arg);
         }
 
-        Self::try_parse_from(args)
+        Self::try_parse_from(args).map(|mut opts| {
+            opts.cmd
+                .get_or_insert(std::env::var("SKIM_DEFAULT_COMMAND").unwrap_or(SKIM_DEFAULT_COMMAND.to_string()));
+            opts
+        })
     }
 }
 

--- a/src/popup/mod.rs
+++ b/src/popup/mod.rs
@@ -180,13 +180,7 @@ pub fn run_with(opts: &SkimOptions) -> Option<SkimOutput> {
     // Always add all --print-xxx flags to the child sk command so that the output
     // is fully structured and can be parsed unconditionally below, regardless of
     // which flags the user originally passed.
-    for flag in &[
-        "--print-query",
-        "--print-cmd",
-        "--print-header",
-        "--print-current",
-        "--print-score",
-    ] {
+    for flag in &["--print-query", "--print-header", "--print-current", "--print-score"] {
         let _ = write!(stripped_shell_cmd, " {flag}");
     }
 
@@ -233,12 +227,6 @@ pub fn run_with(opts: &SkimOptions) -> Option<SkimOutput> {
     // The child sk process always runs with --print-query, --print-cmd, --print-header,
     // and --print-score, so we always read those lines unconditionally.
     let query_str = if status.success() {
-        stdout.next().unwrap_or_default()
-    } else {
-        ""
-    };
-
-    let command_str = if status.success() {
         stdout.next().unwrap_or_default()
     } else {
         ""
@@ -300,7 +288,7 @@ pub fn run_with(opts: &SkimOptions) -> Option<SkimOutput> {
         // popup process. Only the output text is captured. Use --expect with --bind to capture
         // specific accept keys in the output if needed.
         query: query_str.to_string(),
-        cmd: command_str.to_string(),
+        cmd: opts.cmd.clone().unwrap_or_default(),
         selected_items: output_lines,
         current,
         header,

--- a/src/popup/mod.rs
+++ b/src/popup/mod.rs
@@ -167,6 +167,9 @@ pub fn run_with(opts: &SkimOptions) -> Option<SkimOutput> {
         } else if arg.starts_with("--tmux") || arg.starts_with("--popup") {
             debug!("Found equal popup arg, skipping");
             continue;
+        } else if arg == "--print-cmd" {
+            debug!("Found print cmd arg, skipping");
+            continue;
         } else if arg == "--output-format" {
             debug!("Found output format arg, skipping this and the next");
             prev_is_output_format_flag = true;

--- a/src/skim.rs
+++ b/src/skim.rs
@@ -1,5 +1,4 @@
 //! Module containing skim's entry point
-use std::env;
 use std::io::{BufWriter, Stderr};
 use std::sync::Arc;
 use std::time::Duration;
@@ -146,11 +145,7 @@ where
         // Initialize theme from options
         let theme = Arc::new(crate::theme::ColorTheme::init_from_options(&options));
         let mut reader = Reader::from_options(&options).source(source);
-        let default_command = String::from(match env::var("SKIM_DEFAULT_COMMAND").as_deref() {
-            Err(_) | Ok("") => crate::SKIM_DEFAULT_COMMAND,
-            Ok(v) => v,
-        });
-        let cmd = options.cmd.clone().unwrap_or(default_command);
+        let cmd = options.cmd.clone().unwrap_or_default();
 
         let app = App::from_options(options, theme.clone(), cmd.clone());
 

--- a/tests/popup.rs
+++ b/tests/popup.rs
@@ -77,7 +77,6 @@ fn tmux_vanilla() -> Result<()> {
     assert!(cmd.starts_with("display-popup"));
     assert!(cmd.contains("-E"));
     assert!(cmd.contains("--print-query"));
-    assert!(cmd.contains("--print-cmd"));
     assert!(cmd.contains("--print-header"));
     assert!(cmd.contains("--print-current"));
     assert!(cmd.contains("--print-score"));
@@ -104,7 +103,6 @@ fn tmux_output_format() -> Result<()> {
     assert!(cmd.starts_with("display-popup"));
     assert!(cmd.contains("-E"));
     assert!(cmd.contains("--print-query"));
-    assert!(cmd.contains("--print-cmd"));
     assert!(cmd.contains("--print-header"));
     assert!(cmd.contains("--print-current"));
     assert!(cmd.contains("--print-score"));

--- a/tests/unix.rs
+++ b/tests/unix.rs
@@ -193,50 +193,54 @@ sk_test!(opt_reserved_options, "a\\nb", &[], tmux => {
   }
 });
 
-sk_test!(opt_multiple_flags_basic, "a\\nb", &[], tmux => {
-  let basic_flags = [
-      "--bind=ctrl-a:cancel --bind ctrl-b:cancel",
-      "--tiebreak=begin --tiebreak=score",
-      "--cmd asdf --cmd find",
-      "--query asdf -q xyz",
-      "--delimiter , --delimiter . -d ,",
-      "--nth 1,2 --nth=1,3 -n 1,3",
-      "--with-nth 1,2 --with-nth=1,3",
-      "-I {} -I XX",
-      "--color base --color light",
-      "--margin 30% --margin 0",
-      "--min-height 30% --min-height 10",
-      "--preview 'ls {}' --preview 'cat {}'",
-      "--preview-window up --preview-window down",
-      "--multi -m",
-      "--no-multi --no-multi",
-      "--tac --tac",
-      "--ansi --ansi",
-      "--exact -e",
-      "--regex --regex",
-      "--literal --literal",
-      "--no-mouse --no-mouse",
-      "--cycle --cycle",
-      "--no-hscroll --no-hscroll",
-      "--filepath-word --filepath-word",
-      "--inline-info --inline-info",
-      "--no-bold --no-bold",
-      "--print-query --print-query",
-      "--print-cmd --print-cmd",
-      "--print0 --print0",
-      "--sync --sync",
-      "--extended --extended",
-      "--no-sort --no-sort",
-      "--select-1 --select-1",
-      "--exit-0 --exit-0",
-  ];
+macro_rules! test_opt_multiple_flags {
+    ($idx: ident, $flags:literal) => {
+        mod $idx {
+            use super::*;
+            sk_test!(opt_multiple_flags_basic, "", &[], tmux => {
+                  let mut tmux = TmuxController::new()?;
+                  tmux.start_sk(Some("echo -n -e 'a\\nb\\nc'"), &[ $flags ])?;
+                  tmux.until(|l| !l.is_empty())?;
+                  tmux.until(|l| l[0].starts_with(">"))?;
+            });
+        }
+    };
+}
 
-  for cmd_flags in basic_flags {
-      let mut tmux = TmuxController::new()?;
-      tmux.start_sk(None, &[cmd_flags])?;
-      tmux.until(|l| !l.is_empty() && l[0].starts_with(">"))?;
-  }
-});
+test_opt_multiple_flags!(bind, "--bind=ctrl-a:cancel --bind ctrl-b:cancel");
+test_opt_multiple_flags!(tiebreak, "--tiebreak=begin --tiebreak=score");
+test_opt_multiple_flags!(cmd, "--cmd asdf --cmd find");
+test_opt_multiple_flags!(query, "--query asdf -q xyz");
+test_opt_multiple_flags!(delimiter, "--delimiter , --delimiter . -d ,");
+test_opt_multiple_flags!(nth, "--nth 1,2 --nth=1,3 -n 1,3");
+test_opt_multiple_flags!(with_nth, "--with-nth 1,2 --with-nth=1,3");
+test_opt_multiple_flags!(replstr, "-I {} -I XX");
+test_opt_multiple_flags!(color, "--color base --color light");
+test_opt_multiple_flags!(margin, "--margin 30% --margin 0");
+test_opt_multiple_flags!(min_height, "--min-height 30% --min-height 10");
+test_opt_multiple_flags!(preview, "--preview 'ls {}' --preview 'cat {}'");
+test_opt_multiple_flags!(preview_window, "--preview-window up --preview-window down");
+test_opt_multiple_flags!(multi, "--multi -m");
+test_opt_multiple_flags!(no_multi, "--no-multi --no-multi");
+test_opt_multiple_flags!(tac, "--tac --tac");
+test_opt_multiple_flags!(ansi, "--ansi --ansi");
+test_opt_multiple_flags!(exact, "--exact -e");
+test_opt_multiple_flags!(regex, "--regex --regex");
+test_opt_multiple_flags!(literal, "--literal --literal");
+test_opt_multiple_flags!(no_mouse, "--no-mouse --no-mouse");
+test_opt_multiple_flags!(cycle, "--cycle --cycle");
+test_opt_multiple_flags!(no_hscroll, "--no-hscroll --no-hscroll");
+test_opt_multiple_flags!(filepath_word, "--filepath-word --filepath-word");
+test_opt_multiple_flags!(inline_info, "--inline-info --inline-info");
+test_opt_multiple_flags!(no_bold, "--no-bold --no-bold");
+test_opt_multiple_flags!(print_query, "--print-query --print-query");
+test_opt_multiple_flags!(print_cmd, "--print-cmd --print-cmd");
+test_opt_multiple_flags!(print0, "--print0 --print0");
+test_opt_multiple_flags!(sync, "--sync --sync");
+test_opt_multiple_flags!(extended, "--extended --extended");
+test_opt_multiple_flags!(no_sort, "--no-sort --no-sort");
+test_opt_multiple_flags!(select_1, "--select-1 --select-1");
+test_opt_multiple_flags!(exit_0, "--exit-0 --exit-0");
 
 use std::io::Write;
 use tempfile::NamedTempFile;


### PR DESCRIPTION
…line

closes #1086

## Checklist

- [x] The title of my PR follows [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] I have updated the documentation (`README.md`, comments, `src/manpage.rs` and/or `src/options.rs` if applicable) 
- [x] I have added unit tests
- [x] I have added [integration tests](https://github.com/skim-rs/skim/tree/master/tests)
- [x] I have linked all related issues or PRs

## Description of the changes

_Note_: [codecov](https://codecov.io) runs on the PR on this repo, but feel free to ignore it.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed popup invocation and parsing so popups are handled reliably across tmux/zellij.
* **Behavior Changes**
  * Popup output now explicitly exposes query, header, current and score fields and no longer emits a printed command field.
  * The command option now always has a defined default, stabilizing behavior when no command is provided.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->