### PR TITLE
feat(ci): upload coverage report to pages for easier browsing

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -93,6 +93,8 @@ jobs:
     permissions:
       "code-quality": "write"
       "contents": "read"
+      "id-token": "write"
+      "pages": "write"
 
   # Build and packages all the platform-specific things
   build-local-artifacts:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -17,11 +17,8 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  nextest: &job
+  nextest:
     runs-on: ${{matrix.os}}
-    permissions:
-      contents: read
-      code-quality: write
     strategy:
       matrix:
         build: [linux, macos, windows]
@@ -35,6 +32,9 @@ jobs:
           - build: windows
             os: windows-latest
             target: x86_64-pc-windows-msvc
+    permissions:
+      contents: read
+      code-quality: write
     steps:
       - name: "[linux] Install dependencies"
         run: |
@@ -145,7 +145,20 @@ jobs:
         uses: actions/deploy-pages@v4
 
   clippy:
-    <<: *job
+    runs-on: ${{matrix.os}}
+    strategy:
+      matrix:
+        build: [linux, macos, windows]
+        include:
+          - build: linux
+            os: ubuntu-latest
+            target: x86_64-unknown-linux-musl
+          - build: macos
+            os: macos-latest
+            target: x86_64-apple-darwin
+          - build: windows
+            os: windows-latest
+            target: x86_64-pc-windows-msvc
     steps:
       - name: Checkout repository
         uses: actions/checkout@v6
@@ -159,7 +172,20 @@ jobs:
         run: cargo clippy
 
   rustfmt:
-    <<: *job
+    runs-on: ${{matrix.os}}
+    strategy:
+      matrix:
+        build: [linux, macos, windows]
+        include:
+          - build: linux
+            os: ubuntu-latest
+            target: x86_64-unknown-linux-musl
+          - build: macos
+            os: macos-latest
+            target: x86_64-apple-darwin
+          - build: windows
+            os: windows-latest
+            target: x86_64-pc-windows-msvc
     steps:
       - name: Checkout repository
         uses: actions/checkout@v6
@@ -169,7 +195,20 @@ jobs:
           cargo fmt --all -- --check
 
   build-no-default-features:
-    <<: *job
+    runs-on: ${{matrix.os}}
+    strategy:
+      matrix:
+        build: [linux, macos, windows]
+        include:
+          - build: linux
+            os: ubuntu-latest
+            target: x86_64-unknown-linux-musl
+          - build: macos
+            os: macos-latest
+            target: x86_64-apple-darwin
+          - build: windows
+            os: windows-latest
+            target: x86_64-pc-windows-msvc
     steps:
       - name: Checkout repository
         uses: actions/checkout@v6

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -116,7 +116,7 @@ jobs:
           language: Rust
           label: ${{ runner.os }}
       - name: "[linux] Generate coverage badge"
-        if: &if-linux-master runner.os == 'Linux' # TODO && github.ref == format('refs/heads/{0}', github.event.repository.default_branch)
+        if: &if-linux-master runner.os == 'Linux' && github.ref == format('refs/heads/{0}', github.event.repository.default_branch)
         uses: emibcn/badge-action@v2.0.2
         with:
           label: 'Coverage'

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -79,8 +79,8 @@ jobs:
         # Do not use `--all-targets` to avoid running benches
         run: |
           cargo llvm-cov nextest --release --profile ci --bins --lib --examples --tests --no-report
-          cargo llvm-cov report --cobertura --output-path coverage.xml
-          cargo llvm-cov report --html
+          cargo llvm-cov report --release --cobertura --output-path coverage.xml
+          cargo llvm-cov report --release --html
           echo "COVERAGE_PERCENT=$(cargo llvm-cov report | tail -n1 | awk '{ print $4 }')" >> $GITHUB_ENV
         env:
           LC_ALL: en_US.UTF-8

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -81,7 +81,7 @@ jobs:
           cargo llvm-cov nextest --release --profile ci --bins --lib --examples --tests --no-report
           cargo llvm-cov report --release --cobertura --output-path coverage.xml
           cargo llvm-cov report --release --html
-          echo "COVERAGE_PERCENT=$(cargo llvm-cov report | tail -n1 | awk '{ print $4 }')" >> $GITHUB_ENV
+          echo "COVERAGE_PERCENT=$(cargo llvm-cov report --release | tail -n1 | awk '{ print $4 }')" | tee --append $GITHUB_ENV
         env:
           LC_ALL: en_US.UTF-8
           TERM: xterm-256color

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -17,7 +17,7 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  nextest:
+  nextest: &job
     runs-on: ${{matrix.os}}
     permissions:
       contents: read
@@ -50,6 +50,7 @@ jobs:
         if: runner.os == 'macOS'
         env:
           HOMEBREW_NO_AUTO_UPDATE: 1
+
       - name: Checkout repository
         uses: actions/checkout@v6
         with:
@@ -70,11 +71,24 @@ jobs:
           env-vars: "____"
           cache-on-failure: "true"
           cache-all-crates: "true"
+
       - name: Run doctests
         run: cargo test --doc
-      - name: Run tests
+      - name: "[linux] Run tests with coverage"
+        if: runner.os == 'Linux'
         # Do not use `--all-targets` to avoid running benches
-        run: cargo llvm-cov nextest --release --profile ci --bins --lib --examples --tests --cobertura --output-path coverage.xml --failure-mode all
+        run: |
+          cargo llvm-cov nextest --release --profile ci --bins --lib --examples --tests --no-report
+          cargo llvm-cov report --cobertura --output-path coverage.xml
+          cargo llvm-cov report --html
+          echo "COVERAGE_PERCENT=$(cargo llvm-cov report | tail -n1 | awk '{ print $4 }')" >> $GITHUB_ENV
+        env:
+          LC_ALL: en_US.UTF-8
+          TERM: xterm-256color
+      - name: "[macos/windows] Run tests"
+        if: runner.os != 'Linux'
+        # Do not use `--all-targets` to avoid running benches
+        run: cargo nextest run --release --profile ci --bins --lib --examples --tests
         env:
           LC_ALL: en_US.UTF-8
           TERM: xterm-256color
@@ -93,17 +107,45 @@ jobs:
             fi
           done
         shell: bash
-      - name: Upload coverage report
-        if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository
-        # fail-on-error: false
+      - name: "[linux] Upload coverage report"
+        if: runner.os == 'Linux' && (github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository)
+        continue-on-error: true
         uses: actions/upload-code-coverage@v1
         with:
           file: coverage.xml
           language: Rust
           label: ${{ runner.os }}
+      - name: "[linux] Generate coverage badge"
+        if: &if-linux-master runner.os == 'Linux' # TODO && github.ref == format('refs/heads/{0}', github.event.repository.default_branch)
+        uses: emibcn/badge-action@v2.0.2
+        with:
+          label: 'Coverage'
+          status: ${{ env.COVERAGE_PERCENT }}
+          color: 'blue'
+          path: 'target/llvm-cov/html/coverage.svg'
+      - name: "[linux] Upload default branch results to gh pages"
+        if: *if-linux-master
+        uses: actions/upload-pages-artifact@v3
+        with:
+          path: target/llvm-cov/html
+
+  deploy-coverage-page:
+    needs: nextest
+    permissions:
+      pages: write
+      id-token: write
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    runs-on: ubuntu-latest
+    steps:
+      - name: "[linux] Deploy gh pages"
+        id: deployment
+        if: *if-linux-master
+        uses: actions/deploy-pages@v4
 
   clippy:
-    runs-on: ubuntu-latest
+    <<: *job
     steps:
       - name: Checkout repository
         uses: actions/checkout@v6
@@ -117,7 +159,7 @@ jobs:
         run: cargo clippy
 
   rustfmt:
-    runs-on: ubuntu-latest
+    <<: *job
     steps:
       - name: Checkout repository
         uses: actions/checkout@v6
@@ -125,6 +167,20 @@ jobs:
       - name: Check formatting
         run: |
           cargo fmt --all -- --check
+
+  build-no-default-features:
+    <<: *job
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v6
+      - run: rustup toolchain install
+      - name: Cache
+        uses: Swatinem/rust-cache@v2
+        with: *cache-with
+      - name: Build without any feature
+        run: |
+          cargo build --no-default-features
+
 
   msrv:
     runs-on: ubuntu-latest
@@ -139,16 +195,3 @@ jobs:
           tool: cargo-msrv@0.19
       - name: MSRV Verify
         run: cargo msrv verify
-
-  build-no-default-features:
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout repository
-        uses: actions/checkout@v6
-      - run: rustup toolchain install
-      - name: Cache
-        uses: Swatinem/rust-cache@v2
-        with: *cache-with
-      - name: Build without any feature
-        run: |
-          cargo build --no-default-features

--- a/.gitignore
+++ b/.gitignore
@@ -37,3 +37,4 @@ __pycache__/
 /public
 
 .codex
+/coverage.xml

--- a/README.md
+++ b/README.md
@@ -5,6 +5,9 @@
   <a href="https://github.com/skim-rs/skim/actions?query=workflow%3A%22Build+%26+Test%22+event%3Apush">
     <img src="https://github.com/skim-rs/skim/actions/workflows/test.yml/badge.svg?event=push" alt="Build & Test" />
   </a>
+  <a href="https://skim-rs.github.io/skim" >
+    <img src="https://skim-rs.github.io/skim/coverage.svg" alt="coverage badge" />
+  </a>
   <a href="https://repology.org/project/skim-fuzzy-finder/versions">
     <img src="https://repology.org/badge/tiny-repos/skim-fuzzy-finder.svg" alt="Packaging status" />
   </a>

--- a/dist-workspace.toml
+++ b/dist-workspace.toml
@@ -27,3 +27,5 @@ publish-prereleases = true
 [dist.github-custom-job-permissions.test]
 code-quality = "write"
 contents = "read"
+pages = "write"
+id-token = "write"


### PR DESCRIPTION
## Checklist

- [ ] The title of my PR follows [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/)
- [ ] I have updated the documentation (`README.md`, comments, `src/manpage.rs` and/or `src/options.rs` if applicable) 
- [ ] I have added unit tests
- [ ] I have added [integration tests](https://github.com/skim-rs/skim/tree/master/tests)
- [ ] I have linked all related issues or PRs

## Description of the changes




<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added Linux CI coverage generation (Cobertura XML + HTML) and an auto-generated coverage badge.
  * Publishes the HTML coverage report to a hosted Pages site and links it from the README.
* **Bug Fixes**
  * Updated CI permissions to allow coverage upload and Pages publishing.
* **Chores**
  * Refactored the test workflow to reuse shared configuration, split coverage by OS, and deploy coverage via a dedicated Pages job.
  * Expanded formatting to a multi-OS matrix, added a no-default-features build, removed MSRV verification, and updated ignore rules for coverage artifacts.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->