### PR TITLE
fix: preserve input order with --no-sort

### DIFF
--- a/src/matcher.rs
+++ b/src/matcher.rs
@@ -21,7 +21,9 @@ use crate::{CaseMatching, MatchEngineFactory, SkimItem, SkimOptions};
 /// this consistently outperforms tree-based or fold-based merge strategies
 /// due to driftsort's cache-friendly single-buffer merge passes.
 ///
-/// When `no_sort` is true, the worker results are simply flattened.
+/// When `no_sort` is true, items are sorted by `rank.index` instead, restoring
+/// the original input order: workers grab chunks from a shared queue, so the
+/// concatenation order of worker results is nondeterministic.
 ///
 /// Signals `needs_render` after writing so the UI picks up the new data.
 fn merge_worker_results(
@@ -42,7 +44,9 @@ fn merge_worker_results(
     // (driftsort since 1.81, a TimSort variant before that) detects
     // pre-existing runs and merges them in O(n log k) for k workers,
     // all on contiguous memory with a single auxiliary buffer.
-    if !no_sort {
+    if no_sort {
+        items.sort_by_key(|item| item.rank.index);
+    } else {
         items.sort();
     }
 
@@ -376,7 +380,12 @@ impl Matcher {
                 // cost.  The final merge uses sort() so that driftsort can
                 // exploit the k sorted runs produced by the workers.
                 move |acc: &mut Vec<MatchedItem>| {
-                    if !no_sort {
+                    if no_sort {
+                        // Chunks are grabbed from a shared queue, so the
+                        // accumulator is not in input order; sort by index
+                        // so the final merge sees k sorted runs here too.
+                        acc.sort_unstable_by_key(|item| item.rank.index);
+                    } else {
                         acc.sort_unstable();
                     }
                 },
@@ -467,6 +476,25 @@ mod tests {
         let guard = processed.lock();
         let items = &guard.as_ref().unwrap().items;
         assert_eq!(items.len(), 2);
+    }
+
+    #[test]
+    fn merge_worker_results_no_sort_restores_input_order() {
+        let processed = SpinLock::new(None);
+        let needs_render = AtomicBool::new(false);
+        // Worker slots arrive in nondeterministic order (chunks are grabbed
+        // from a shared queue), so the concatenation is not in input order.
+        let workers = vec![
+            vec![matched("e", 4), matched("f", 5)],
+            vec![matched("c", 2), matched("d", 3)],
+            vec![matched("a", 0), matched("b", 1)],
+        ];
+        merge_worker_results(workers, true, &processed, MergeStrategy::Replace, &needs_render);
+
+        let guard = processed.lock();
+        let items = &guard.as_ref().unwrap().items;
+        let indexes: Vec<i32> = items.iter().map(|item| item.rank.index).collect();
+        assert_eq!(indexes, vec![0, 1, 2, 3, 4, 5]);
     }
 
     #[test]

--- a/src/matcher.rs
+++ b/src/matcher.rs
@@ -21,9 +21,8 @@ use crate::{CaseMatching, MatchEngineFactory, SkimItem, SkimOptions};
 /// this consistently outperforms tree-based or fold-based merge strategies
 /// due to driftsort's cache-friendly single-buffer merge passes.
 ///
-/// When `no_sort` is true, items are sorted by `rank.index` instead, restoring
-/// the original input order: workers grab chunks from a shared queue, so the
-/// concatenation order of worker results is nondeterministic.
+/// When `no_sort` is true, worker results arrive in chunk-index order and are
+/// flattened without sorting.
 ///
 /// Signals `needs_render` after writing so the UI picks up the new data.
 fn merge_worker_results(
@@ -39,14 +38,9 @@ fn merge_worker_results(
         items.extend(chunk);
     }
 
-    // Each worker's sub-list is already sorted by `prepare`, so the
-    // concatenated Vec consists of k sorted runs.  Rust's stable sort
-    // (driftsort since 1.81, a TimSort variant before that) detects
-    // pre-existing runs and merges them in O(n log k) for k workers,
-    // all on contiguous memory with a single auxiliary buffer.
-    if no_sort {
-        items.sort_by_key(|item| item.rank.index);
-    } else {
+    if !no_sort {
+        // Each worker's sub-list is already sorted by `prepare`, so stable
+        // sort detects the pre-existing runs and merges them efficiently.
         items.sort();
     }
 
@@ -325,6 +319,7 @@ impl Matcher {
                 num_workers,
                 &shared_items,
                 CHUNK_SIZE,
+                no_sort,
                 // identity – seed value for each worker's local accumulator
                 Vec::<MatchedItem>::new,
                 // process_chunk – called for each chunk; returns a Vec of matches
@@ -379,16 +374,7 @@ impl Matcher {
                 // chunk order), so driftsort's run-detection overhead is pure
                 // cost.  The final merge uses sort() so that driftsort can
                 // exploit the k sorted runs produced by the workers.
-                move |acc: &mut Vec<MatchedItem>| {
-                    if no_sort {
-                        // Chunks are grabbed from a shared queue, so the
-                        // accumulator is not in input order; sort by index
-                        // so the final merge sees k sorted runs here too.
-                        acc.sort_unstable_by_key(|item| item.rank.index);
-                    } else {
-                        acc.sort_unstable();
-                    }
-                },
+                |acc: &mut Vec<MatchedItem>| acc.sort_unstable(),
                 // merge – concat pre-sorted worker results and sort().
                 // Rust's stable sort detects the k sorted runs and merges
                 // them in O(n log k), then writes into processed_items.
@@ -479,15 +465,13 @@ mod tests {
     }
 
     #[test]
-    fn merge_worker_results_no_sort_restores_input_order() {
+    fn merge_worker_results_no_sort_preserves_chunk_order() {
         let processed = SpinLock::new(None);
         let needs_render = AtomicBool::new(false);
-        // Worker slots arrive in nondeterministic order (chunks are grabbed
-        // from a shared queue), so the concatenation is not in input order.
         let workers = vec![
-            vec![matched("e", 4), matched("f", 5)],
-            vec![matched("c", 2), matched("d", 3)],
             vec![matched("a", 0), matched("b", 1)],
+            vec![matched("c", 2), matched("d", 3)],
+            vec![matched("e", 4), matched("f", 5)],
         ];
         merge_worker_results(workers, true, &processed, MergeStrategy::Replace, &needs_render);
 

--- a/src/thread_pool.rs
+++ b/src/thread_pool.rs
@@ -277,7 +277,7 @@ impl<R> Slot<R> {
 // ---------------------------------------------------------------------------
 
 /// Processes `items` in parallel across `num_workers` threads from the given
-/// pool, then hands the per-worker results to `merge`.
+/// pool, then hands the results to `merge`.
 ///
 /// The work is split into chunks of `chunk_size`.  Each worker thread
 /// repeatedly grabs the next available chunk (via an atomic counter), runs
@@ -285,8 +285,10 @@ impl<R> Slot<R> {
 /// accumulator using `reduce`.  When all chunks are consumed, each worker
 /// calls `prepare` on its local accumulator (e.g. to sort it) — this step
 /// runs **in parallel** across all workers — and then writes the prepared
-/// result into its slot.  The coordinator collects every worker's result and
-/// passes them all to `merge` in a single call.
+/// result into its slot. The coordinator collects every worker's result and
+/// passes them all to `merge` in a single call. When `preserve_chunk_order` is
+/// set, reduction and preparation are skipped and each chunk result is stored
+/// directly in its chunk-indexed slot.
 ///
 /// Because each worker picks up the *next* chunk as soon as it finishes the
 /// previous one, faster threads naturally do more work without any explicit
@@ -298,6 +300,7 @@ impl<R> Slot<R> {
 /// * `num_workers`    – how many workers to dispatch (capped to pool size internally by caller).
 /// * `items`          – the data to process; shared read-only across workers via `Arc`.
 /// * `chunk_size`     – number of items per chunk.
+/// * `preserve_chunk_order` – store results by chunk index and skip reduction/preparation.
 /// * `identity`       – the identity/seed value for per-worker local accumulators (called once per worker).
 /// * `process_chunk`  – `(chunk_start_index, &[T]) -> R` – processes one chunk.
 /// * `reduce`         – folds a per-chunk result into a worker-local accumulator (`&mut acc, partial`).
@@ -309,6 +312,7 @@ pub fn parallel_work_queue<S, T, R, P, M, I, W, G>(
     num_workers: usize,
     items: &Arc<S>,
     chunk_size: usize,
+    preserve_chunk_order: bool,
     identity: I,
     process_chunk: P,
     reduce: M,
@@ -336,10 +340,10 @@ pub fn parallel_work_queue<S, T, R, P, M, I, W, G>(
     // Shared atomic counter – workers fetch-add to grab the next chunk index.
     let next_chunk = Arc::new(AtomicUsize::new(0));
 
-    // Contiguous, cache-line-aligned per-worker result slots.  Each worker
-    // writes only to its own slot (lock-free via UnsafeCell); the
-    // coordinator reads after the AtomicCounter barrier.
-    let slots: Arc<Vec<Slot<R>>> = Arc::new((0..num_workers).map(|_| Slot::new()).collect());
+    // Ordered mode uses one slot per chunk; otherwise each worker writes its
+    // reduced result to its own slot. The coordinator reads only after the barrier.
+    let num_slots = if preserve_chunk_order { num_chunks } else { num_workers };
+    let slots: Arc<Vec<Slot<R>>> = Arc::new((0..num_slots).map(|_| Slot::new()).collect());
 
     // Barrier: we wait until all workers have finished.
     let remaining = Arc::new(AtomicCounter::new(num_workers));
@@ -368,9 +372,25 @@ pub fn parallel_work_queue<S, T, R, P, M, I, W, G>(
                 // Scope all Arc-holding work so clones are dropped before we
                 // signal completion.  This lets the coordinator safely unwrap
                 // the outer Arcs.
-                let local_acc = {
-                    let mut local_acc = w_identity();
+                let local_acc = if preserve_chunk_order {
+                    loop {
+                        let chunk_idx = w_next_chunk.fetch_add(1, Ordering::Relaxed);
+                        if chunk_idx >= num_chunks {
+                            break;
+                        }
 
+                        let start = chunk_idx * chunk_size;
+                        let end = total.min(start + chunk_size);
+                        let slice: &[T] = AsRef::<[T]>::as_ref(&*w_items);
+                        let partial = w_process_chunk(start, &slice[start..end]);
+
+                        // SAFETY: every chunk index is handed out once, so each
+                        // slot has one writer. The coordinator reads after the barrier.
+                        unsafe { *w_slots[chunk_idx].value.get() = Some(partial) };
+                    }
+                    None
+                } else {
+                    let mut local_acc = w_identity();
                     loop {
                         let chunk_idx = w_next_chunk.fetch_add(1, Ordering::Relaxed);
                         if chunk_idx >= num_chunks {
@@ -387,16 +407,14 @@ pub fn parallel_work_queue<S, T, R, P, M, I, W, G>(
                     // Run prepare (e.g. sort) while still on the worker thread
                     // so that this work happens in parallel across workers.
                     w_prepare(&mut local_acc);
-
-                    // w_items, w_next_chunk, w_process_chunk, w_reduce,
-                    // w_prepare, w_identity are dropped when this block ends.
-                    local_acc
+                    Some(local_acc)
                 };
 
-                // Write into our own slot – lock-free, no contention.
-                // SAFETY: each worker_id is unique; no other thread writes to
-                // this slot, and the coordinator reads only after the barrier.
-                unsafe { *w_slots[worker_id].value.get() = Some(local_acc) };
+                if let Some(local_acc) = local_acc {
+                    // SAFETY: each worker_id is unique; no other thread writes to
+                    // this slot, and the coordinator reads only after the barrier.
+                    unsafe { *w_slots[worker_id].value.get() = Some(local_acc) };
+                }
 
                 // Drop the slots Arc *before* signalling completion.
                 // The coordinator calls Arc::into_inner(slots) after wait_for_zero
@@ -418,7 +436,7 @@ pub fn parallel_work_queue<S, T, R, P, M, I, W, G>(
     // Block until all workers are done.
     remaining.wait_for_zero();
 
-    // Collect per-worker results and hand them to `merge` in one call.
+    // Collect worker or chunk results in slot order and hand them to `merge`.
     // Workers dropped their `w_slots` Arc clone explicitly before signalling
     // completion, so we are the sole owner here.
     if let Some(slots) = Arc::into_inner(slots) {

--- a/src/thread_pool_tests.rs
+++ b/src/thread_pool_tests.rs
@@ -72,6 +72,7 @@ fn parallel_work_queue_sums() {
         4,
         &items,
         64,
+        false,
         || 0u64,
         |_start, chunk| chunk.iter().sum::<u64>(),
         |acc, partial| *acc += partial,
@@ -86,6 +87,29 @@ fn parallel_work_queue_sums() {
 }
 
 #[test]
+fn parallel_work_queue_preserves_chunk_order() {
+    let pool = ThreadPool::new(4);
+    let items: Arc<[usize]> = (0..40).collect::<Vec<_>>().into();
+    let mut starts = Vec::new();
+    parallel_work_queue(
+        &pool,
+        4,
+        &items,
+        10,
+        true,
+        || -> Vec<usize> { panic!("ordered mode must not create accumulators") },
+        |start, _chunk| {
+            std::thread::sleep(std::time::Duration::from_millis((30 - start) as u64));
+            vec![start]
+        },
+        |_acc, _partial| panic!("ordered mode must not reduce"),
+        |_acc| panic!("ordered mode must not prepare"),
+        |chunk_results| starts.extend(chunk_results.into_iter().flatten()),
+    );
+    assert_eq!(starts, vec![0, 10, 20, 30]);
+}
+
+#[test]
 fn parallel_work_queue_empty() {
     let pool = ThreadPool::new(2);
     let items: Arc<[u64]> = Arc::from(Vec::<u64>::new().into_boxed_slice());
@@ -95,6 +119,7 @@ fn parallel_work_queue_empty() {
         2,
         &items,
         64,
+        false,
         Vec::<u64>::new,
         |_start, chunk| chunk.to_vec(),
         |acc, mut partial| acc.append(&mut partial),
@@ -118,6 +143,7 @@ fn parallel_work_queue_single_thread() {
         1,
         &items,
         10,
+        false,
         || 0i32,
         |_start, chunk| chunk.iter().sum::<i32>(),
         |acc, partial| *acc += partial,
@@ -156,6 +182,7 @@ fn parallel_work_queue_many_workers_few_chunks() {
         8,
         &items,
         5,
+        false,
         || 0u64,
         |_start, chunk| chunk.iter().sum::<u64>(),
         |acc, partial| *acc += partial,
@@ -186,6 +213,7 @@ fn parallel_work_queue_single_thread_pool_no_deadlock() {
             1,
             &items,
             10,
+            false,
             || 0u64,
             |_start, chunk| chunk.iter().sum::<u64>(),
             |acc, partial| *acc += partial,

--- a/tests/cli.rs
+++ b/tests/cli.rs
@@ -111,6 +111,24 @@ fn filter_mode_with_print0() {
 }
 
 #[test]
+fn filter_mode_no_sort_preserves_input_order() {
+    // Workers grab 4096-item chunks from a shared queue, so with enough items
+    // each worker processes several chunks and the concatenation order of
+    // worker results is nondeterministic. --no-sort must restore input order.
+    let input: String = (0..50_000).map(|i| format!("item{i:06} x\n")).collect();
+    let expected: Vec<String> = (0..50_000).map(|i| format!("item{i:06} x")).collect();
+    let (code, stdout, _) = run_sk_argv(&input, &["--no-sort", "-f", "x"], &[]);
+    assert_eq!(code, Some(0));
+    let lines: Vec<String> = stdout.lines().map(String::from).collect();
+    assert_eq!(lines.len(), expected.len());
+    let first_mismatch = lines.iter().zip(&expected).position(|(a, b)| a != b);
+    assert!(
+        first_mismatch.is_none(),
+        "output diverges from input order at line {first_mismatch:?}"
+    );
+}
+
+#[test]
 fn select_1_with_output_format() {
     // --output-format renders the selected item through the printf branch.
     let (code, stdout, _) = run_sk("1\\n2\\n3", "--select-1 -q 3 --output-format '{}'");


### PR DESCRIPTION
## Checklist

- [x] The title of my PR follows [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] I have updated the documentation (`README.md`, comments, `src/manpage.rs` and/or `src/options.rs` if applicable)
- [x] I have added unit tests
- [x] I have added [integration tests](https://github.com/skim-rs/skim/tree/master/tests)
- [x] I have linked all related issues or PRs

## Description of the changes

With `--no-sort`, skim is expected to display matches in input order, but beyond a certain input size the order becomes scrambled and nondeterministic.

### Reproduction

Filter mode reproduces it deterministically:

```sh
seq -f 'item%06.0f x' 1 50000 | sk --no-sort --filter x | sort -c
# sort: -:12289: disorder: item004097 x   (varies between runs)
```

The interactive TUI has the same problem: with a large candidate list (e.g. piping a ~65k-line shell history into `sk --no-sort` for a ctrl-r style history widget), the first match for a query is frequently a very old entry instead of the most recent one, and the result changes from run to run. On my 10-core machine the breakage starts at ~24.6k items, which matches `num_workers (⌊2×10/3⌋ = 6) × chunk size (4096)`.

### Root cause

Matcher workers grab 4096-item chunks from a shared queue (`parallel_work_queue`), so which worker processes which chunk is a race. `merge_worker_results` concatenates the per-worker slots in worker-id order, and with `no_sort` it used to leave the result in that arrival order. Once the item count exceeds `num_workers × CHUNK_SIZE`, some worker's slot contains non-adjacent chunks and the concatenation can no longer be in input order. The sorted path is unaffected because `MatchedItem::cmp` tie-breaks on `rank.index`.

### Fix

When `no_sort` is set, sort matched items by `rank.index` — the original input position, which is already computed for every match. Each worker sorts its accumulator in `prepare` (in parallel, mirroring the sorted path), and the final merge sorts the concatenation, exploiting the k sorted runs. The `MergeStrategy::Append` path stays a plain `extend` since appended batches only contain newly read items with strictly higher indexes.

### Verification

- The reproduction above now passes `sort -c`, and the interactive case shows the newest matching item first consistently (5/5 runs on the 65k-line history that reliably failed before).
- New unit test `merge_worker_results_no_sort_restores_input_order` and integration test `filter_mode_no_sort_preserves_input_order`; the latter fails on master at exactly line 4096 (the first chunk boundary) and passes with this fix.
- `cargo test`: 787 lib tests + cli integration tests pass; `cargo clippy` clean.

Related: #919 (a previous `--no-sort` regression, fixed differently — that fix removed the rank sort but left the arrival order in place, which is what this PR addresses).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed `--no-sort` behavior so filtered results preserve their original input order, including when processing data in parallel.

* **Tests**
  * Added coverage verifying chunk-order preservation for parallel processing.
  * Added CLI coverage confirming large filtered inputs retain their original order.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->