### PR TITLE
fix: ignore KeyEventState

### DIFF
--- a/src/tui/app.rs
+++ b/src/tui/app.rs
@@ -675,9 +675,10 @@ impl App {
         self.on_items_updated();
     }
     fn handle_key(&mut self, key: &KeyEvent) -> Vec<Event> {
-        debug!("key event: {key:?}");
+        let normalized_key = KeyEvent::new(key.code, key.modifiers);
+        debug!("key event: {key:?}, normalized: {normalized_key:?}");
 
-        if let Some(act) = &self.options.keymap.get(key) {
+        if let Some(act) = &self.options.keymap.get(&normalized_key) {
             debug!("{act:?}");
             return act.iter().map(|a| Event::Action(a.clone())).collect();
         }

--- a/src/tui/app_tests.rs
+++ b/src/tui/app_tests.rs
@@ -786,7 +786,7 @@ fn handle_key_ctrl_non_char_falls_through_to_empty() {
 fn handle_key_ignore_numlock() {
     let mut app = App::default();
     app.options.keymap.add_keymaps_str("ctrl-a:add-char(a)");
-    // Ctrl + a non-character key with no binding → empty.
+    // NUM_LOCK must not prevent the Ctrl+a binding from matching.
     let key = KeyEvent::new_with_kind_and_state(
         KeyCode::Char('a'),
         KeyModifiers::CONTROL,

--- a/src/tui/app_tests.rs
+++ b/src/tui/app_tests.rs
@@ -783,6 +783,23 @@ fn handle_key_ctrl_non_char_falls_through_to_empty() {
 }
 
 #[test]
+fn handle_key_ignore_numlock() {
+    let mut app = App::default();
+    app.options.keymap.add_keymaps_str("ctrl-a:add-char(a)");
+    // Ctrl + a non-character key with no binding → empty.
+    let key = KeyEvent::new_with_kind_and_state(
+        KeyCode::Char('a'),
+        KeyModifiers::CONTROL,
+        crossterm::event::KeyEventKind::Press,
+        crossterm::event::KeyEventState::NUM_LOCK,
+    );
+    assert!(matches!(
+        app.handle_key(&key).as_slice(),
+        &[Event::Action(Action::AddChar('a'))]
+    ));
+}
+
+#[test]
 fn expand_cmd_substitutes_query() {
     let mut app = App::default();
     app.input.value = "myquery".to_string();


### PR DESCRIPTION
## Checklist

- [x] The title of my PR follows [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/)
- [ ] I have updated the documentation (`README.md`, comments, `src/manpage.rs` and/or `src/options.rs` if applicable) 
- [x] I have added unit tests
- [ ] I have added [integration tests](https://github.com/skim-rs/skim/tree/master/tests)
- [x] I have linked all related issues or PRs

## Description of the changes




<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved keyboard shortcut recognition by matching keymap bindings using a normalized key code and modifiers.
  * Enhanced diagnostic logging to include both the original and normalized key input.
  * Ensured mapped shortcuts continue to work correctly when Num Lock is enabled.
* **Tests**
  * Added a unit test covering keyboard shortcut behavior with Num Lock.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->