### PR TITLE
ci: publish .deb, .rpm and winget packages on release

### DIFF
--- a/.github/workflows/package.yml
+++ b/.github/workflows/package.yml
@@ -1,0 +1,51 @@
+name: Build Linux packages
+
+# Custom dist job (wired in through `build-global-jobs` in dist-workspace.toml).
+# Builds a `.deb` and a `.rpm` containing the `sk` executable, the man pages and
+# the shell completions, then uploads them under an `artifacts-*` name so that
+# dist's `host` job attaches them to the GitHub Release.
+on:
+  workflow_call:
+    inputs:
+      plan:
+        required: true
+        type: string
+
+jobs:
+  linux-packages:
+    name: Build .deb and .rpm
+    runs-on: ubuntu-22.04
+    permissions:
+      contents: read
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v6
+        with:
+          persist-credentials: false
+          submodules: recursive
+      - name: Install Rust
+        run: rustup toolchain install --profile minimal
+      - name: Cache
+        uses: Swatinem/rust-cache@v2
+      - name: Install cargo-deb and cargo-generate-rpm
+        run: |
+          cargo install cargo-deb --locked
+          cargo install cargo-generate-rpm --locked
+      - name: Build release binary
+        run: cargo build --release --bin sk
+      - name: Build .deb package
+        run: cargo deb --no-build --output target/debian
+      - name: Build .rpm package
+        run: cargo generate-rpm
+      - name: Collect packages
+        run: |
+          mkdir -p target/linux-packages
+          cp target/debian/*.deb target/linux-packages/
+          cp target/generate-rpm/*.rpm target/linux-packages/
+          ls -l target/linux-packages/
+      - name: Upload packages
+        uses: actions/upload-artifact@v6
+        with:
+          name: artifacts-linux-packages
+          path: target/linux-packages/*
+          if-no-files-found: error

--- a/.github/workflows/package.yml
+++ b/.github/workflows/package.yml
@@ -48,12 +48,18 @@ jobs:
             echo "::error::Cargo.toml version ($crate_version) does not match the release plan ($plan_version)"
             exit 1
           fi
-      - name: Install cargo-deb and cargo-generate-rpm
+      - name: Install cargo-generate-rpm
         uses: taiki-e/install-action@v2
         with:
-          tool: cargo-deb@3,cargo-generate-rpm@0.21
+          tool: cargo-generate-rpm@0.21
       - name: Setup cargo cache
         uses: Swatinem/rust-cache@v2
+      # cargo-deb's prebuilt binary links GLIBC_2.39, which ubuntu-22.04
+      # (glibc 2.35) lacks. Build it from source so it links the runner's
+      # glibc. We stay on 22.04 on purpose: the sk binary it packages must
+      # keep a low glibc floor for the .deb to run on older distros.
+      - name: Install cargo-deb
+        run: cargo install cargo-deb@3 --locked
       - name: Build release binary
         run: cargo build --release --bin sk
       - name: Build .deb package

--- a/.github/workflows/package.yml
+++ b/.github/workflows/package.yml
@@ -59,7 +59,7 @@ jobs:
       # glibc. We stay on 22.04 on purpose: the sk binary it packages must
       # keep a low glibc floor for the .deb to run on older distros.
       - name: Install cargo-deb
-        run: cargo install cargo-deb@3 --locked
+        run: cargo install 'cargo-deb@^3' --locked
       - name: Build release binary
         run: cargo build --release --bin sk
       - name: Build .deb package

--- a/.github/workflows/package.yml
+++ b/.github/workflows/package.yml
@@ -1,7 +1,7 @@
 name: Build Linux packages
 
-# Custom dist job (wired in through `build-global-jobs` in dist-workspace.toml).
-# Builds a `.deb` and a `.rpm` containing the `sk` executable, the man pages and
+# Custom dist job (wired in through `global-artifacts-jobs` in dist-workspace.toml).
+# Builds a `.deb` and a `.rpm` containing the `sk` executable, the man page and
 # the shell completions, then uploads them under an `artifacts-*` name so that
 # dist's `host` job attaches them to the GitHub Release.
 on:
@@ -19,22 +19,21 @@ jobs:
       contents: read
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
         with:
-          persist-credentials: false
-          submodules: recursive
-      - name: Install Rust
-        run: rustup toolchain install --profile minimal
-      - name: Cache
-        uses: Swatinem/rust-cache@v2
+          fetch-depth: 1
+      - name: Install rust toolchain
+        run: rustup toolchain install
       - name: Install cargo-deb and cargo-generate-rpm
-        run: |
-          cargo install cargo-deb --locked
-          cargo install cargo-generate-rpm --locked
+        uses: taiki-e/install-action@v2
+        with:
+          tool: cargo-deb@3,cargo-generate-rpm@0.21
+      - name: Setup cargo cache
+        uses: Swatinem/rust-cache@v2
       - name: Build release binary
         run: cargo build --release --bin sk
       - name: Build .deb package
-        run: cargo deb --no-build --output target/debian
+        run: cargo deb --no-build
       - name: Build .rpm package
         run: cargo generate-rpm
       - name: Collect packages

--- a/.github/workflows/package.yml
+++ b/.github/workflows/package.yml
@@ -34,6 +34,19 @@ jobs:
           fetch-depth: 1
       - name: Install rust toolchain
         run: rustup toolchain install
+      - name: Check the crate version matches the release plan
+        # These packages are built from the checked-out source (the same tree
+        # dist releases from), so the crate version must match the version dist
+        # planned for this release. Consume the plan to guard against drift.
+        run: |
+          plan_version='${{ fromJson(inputs.plan).announcement_tag }}'
+          plan_version="${plan_version#v}"
+          crate_version="$(cargo metadata --no-deps --format-version 1 | jq -r '.packages[0].version')"
+          echo "release plan: '$plan_version' | crate: '$crate_version'"
+          if [ -n "$plan_version" ] && [ "$plan_version" != "$crate_version" ]; then
+            echo "::error::Cargo.toml version ($crate_version) does not match the release plan ($plan_version)"
+            exit 1
+          fi
       - name: Install cargo-deb and cargo-generate-rpm
         uses: taiki-e/install-action@v2
         with:

--- a/.github/workflows/package.yml
+++ b/.github/workflows/package.yml
@@ -38,9 +38,10 @@ jobs:
         # These packages are built from the checked-out source (the same tree
         # dist releases from), so the crate version must match the version dist
         # planned for this release. Consume the plan to guard against drift.
+        env:
+          ANNOUNCEMENT_TAG: ${{ fromJson(inputs.plan).announcement_tag }}
         run: |
-          plan_version='${{ fromJson(inputs.plan).announcement_tag }}'
-          plan_version="${plan_version#v}"
+          plan_version="${ANNOUNCEMENT_TAG#v}"
           crate_version="$(cargo metadata --no-deps --format-version 1 | jq -r '.packages[0].version')"
           echo "release plan: '$plan_version' | crate: '$crate_version'"
           if [ -n "$plan_version" ] && [ "$plan_version" != "$crate_version" ]; then

--- a/.github/workflows/package.yml
+++ b/.github/workflows/package.yml
@@ -1,9 +1,11 @@
 name: Build Linux packages
 
 # Custom dist job (wired in through `global-artifacts-jobs` in dist-workspace.toml).
-# Builds a `.deb` and a `.rpm` containing the `sk` executable, the man page and
-# the shell completions, then uploads them under an `artifacts-*` name so that
-# dist's `host` job attaches them to the GitHub Release.
+# Builds a `.deb` and a `.rpm` for amd64 and arm64, each containing the `sk`
+# executable, the man page and the shell completions, then uploads them under an
+# `artifacts-*` name so that dist's `host` job attaches them to the GitHub
+# Release. Both architectures build natively (no cross-compilation) on their
+# respective GitHub-hosted runners.
 on:
   workflow_call:
     inputs:
@@ -13,8 +15,16 @@ on:
 
 jobs:
   linux-packages:
-    name: Build .deb and .rpm
-    runs-on: ubuntu-22.04
+    name: Build .deb and .rpm (${{ matrix.arch }})
+    runs-on: ${{ matrix.runner }}
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - arch: amd64
+            runner: ubuntu-22.04
+          - arch: arm64
+            runner: ubuntu-22.04-arm
     permissions:
       contents: read
     steps:
@@ -45,6 +55,6 @@ jobs:
       - name: Upload packages
         uses: actions/upload-artifact@v6
         with:
-          name: artifacts-linux-packages
+          name: artifacts-linux-packages-${{ matrix.arch }}
           path: target/linux-packages/*
           if-no-files-found: error

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -64,9 +64,9 @@ jobs:
         # we specify bash to get pipefail; it guards against the `curl` command
         # failing. otherwise `sh` won't catch that `curl` returned non-0
         shell: bash
-        run: "curl --proto '=https' --tlsv1.2 -LsSf https://github.com/axodotdev/cargo-dist/releases/download/v0.30.4/cargo-dist-installer.sh | sh"
+        run: "curl --proto '=https' --tlsv1.2 -LsSf https://github.com/axodotdev/cargo-dist/releases/download/v0.32.0/cargo-dist-installer.sh | sh"
       - name: Cache dist
-        uses: actions/upload-artifact@v6
+        uses: actions/upload-artifact@v7
         with:
           name: cargo-dist-cache
           path: ~/.cargo/bin/dist
@@ -82,7 +82,7 @@ jobs:
           cat plan-dist-manifest.json
           echo "manifest=$(jq -c "." plan-dist-manifest.json)" >> "$GITHUB_OUTPUT"
       - name: "Upload dist-manifest.json"
-        uses: actions/upload-artifact@v6
+        uses: actions/upload-artifact@v7
         with:
           name: artifacts-plan-dist-manifest
           path: plan-dist-manifest.json
@@ -91,7 +91,6 @@ jobs:
     uses: ./.github/workflows/test.yml
     secrets: inherit
     permissions:
-      "code-quality": "write"
       "contents": "read"
       "id-token": "write"
       "pages": "write"
@@ -137,15 +136,11 @@ jobs:
             curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y
             echo "$HOME/.cargo/bin" >> $GITHUB_PATH
           fi
-      - uses: swatinem/rust-cache@v2
-        with:
-          key: ${{ join(matrix.targets, '-') }}
-          cache-provider: ${{ matrix.cache_provider }}
       - name: Install dist
         run: ${{ matrix.install_dist.run }}
       # Get the dist-manifest
       - name: Fetch local artifacts
-        uses: actions/download-artifact@v7
+        uses: actions/download-artifact@v8
         with:
           pattern: artifacts-*
           path: target/distrib/
@@ -172,7 +167,7 @@ jobs:
 
           cp dist-manifest.json "$BUILD_MANIFEST_NAME"
       - name: "Upload artifacts"
-        uses: actions/upload-artifact@v6
+        uses: actions/upload-artifact@v7
         with:
           name: artifacts-build-local-${{ join(matrix.targets, '_') }}
           path: |
@@ -194,14 +189,14 @@ jobs:
           persist-credentials: false
           submodules: recursive
       - name: Install cached dist
-        uses: actions/download-artifact@v7
+        uses: actions/download-artifact@v8
         with:
           name: cargo-dist-cache
           path: ~/.cargo/bin/
       - run: chmod +x ~/.cargo/bin/dist
       # Get all the local artifacts for the global tasks to use (for e.g. checksums)
       - name: Fetch local artifacts
-        uses: actions/download-artifact@v7
+        uses: actions/download-artifact@v8
         with:
           pattern: artifacts-*
           path: target/distrib/
@@ -219,7 +214,7 @@ jobs:
 
           cp dist-manifest.json "$BUILD_MANIFEST_NAME"
       - name: "Upload artifacts"
-        uses: actions/upload-artifact@v6
+        uses: actions/upload-artifact@v7
         with:
           name: artifacts-build-global
           path: |
@@ -254,14 +249,14 @@ jobs:
           persist-credentials: false
           submodules: recursive
       - name: Install cached dist
-        uses: actions/download-artifact@v7
+        uses: actions/download-artifact@v8
         with:
           name: cargo-dist-cache
           path: ~/.cargo/bin/
       - run: chmod +x ~/.cargo/bin/dist
       # Fetch artifacts from scratch-storage
       - name: Fetch artifacts
-        uses: actions/download-artifact@v7
+        uses: actions/download-artifact@v8
         with:
           pattern: artifacts-*
           path: target/distrib/
@@ -274,14 +269,14 @@ jobs:
           cat dist-manifest.json
           echo "manifest=$(jq -c "." dist-manifest.json)" >> "$GITHUB_OUTPUT"
       - name: "Upload dist-manifest.json"
-        uses: actions/upload-artifact@v6
+        uses: actions/upload-artifact@v7
         with:
           # Overwrite the previous copy
           name: artifacts-dist-manifest
           path: dist-manifest.json
       # Create a GitHub Release while uploading all files to it
       - name: "Download GitHub Artifacts"
-        uses: actions/download-artifact@v7
+        uses: actions/download-artifact@v8
         with:
           pattern: artifacts-*
           path: artifacts

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -221,14 +221,24 @@ jobs:
           path: |
             ${{ steps.cargo-dist.outputs.paths }}
             ${{ env.BUILD_MANIFEST_NAME }}
+
+  custom-package:
+    needs:
+      - plan
+      - build-local-artifacts
+    uses: ./.github/workflows/package.yml
+    with:
+      plan: ${{ needs.plan.outputs.val }}
+    secrets: inherit
   # Determines if we should publish/announce
   host:
     needs:
       - plan
       - build-local-artifacts
       - build-global-artifacts
+      - custom-package
     # Only run if we're "publishing", and only if plan, local and global didn't fail (skipped is fine)
-    if: ${{ always() && needs.plan.result == 'success' && needs.plan.outputs.publishing == 'true' && (needs.build-global-artifacts.result == 'skipped' || needs.build-global-artifacts.result == 'success') && (needs.build-local-artifacts.result == 'skipped' || needs.build-local-artifacts.result == 'success') }}
+    if: ${{ always() && needs.plan.result == 'success' && needs.plan.outputs.publishing == 'true' && (needs.build-global-artifacts.result == 'skipped' || needs.build-global-artifacts.result == 'success') && (needs.custom-package.result == 'skipped' || needs.custom-package.result == 'success') && (needs.build-local-artifacts.result == 'skipped' || needs.build-local-artifacts.result == 'success') }}
     env:
       GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
     runs-on: "ubuntu-22.04"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -316,15 +316,30 @@ jobs:
       "id-token": "write"
       "packages": "write"
 
+  custom-winget:
+    needs:
+      - plan
+      - host
+    if: ${{ !fromJson(needs.plan.outputs.val).announcement_is_prerelease || fromJson(needs.plan.outputs.val).publish_prereleases }}
+    uses: ./.github/workflows/winget.yml
+    with:
+      plan: ${{ needs.plan.outputs.val }}
+    secrets: inherit
+    # publish jobs get escalated permissions
+    permissions:
+      "id-token": "write"
+      "packages": "write"
+
   announce:
     needs:
       - plan
       - host
       - custom-publish
+      - custom-winget
     # use "always() && ..." to allow us to wait for all publish jobs while
     # still allowing individual publish jobs to skip themselves (for prereleases).
     # "host" however must run to completion, no skipping allowed!
-    if: ${{ always() && needs.host.result == 'success' && (needs.custom-publish.result == 'skipped' || needs.custom-publish.result == 'success') }}
+    if: ${{ always() && needs.host.result == 'success' && (needs.custom-publish.result == 'skipped' || needs.custom-publish.result == 'success') && (needs.custom-winget.result == 'skipped' || needs.custom-winget.result == 'success') }}
     runs-on: "ubuntu-22.04"
     env:
       GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -137,6 +137,10 @@ jobs:
             curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y
             echo "$HOME/.cargo/bin" >> $GITHUB_PATH
           fi
+      - uses: swatinem/rust-cache@v2
+        with:
+          key: ${{ join(matrix.targets, '-') }}
+          cache-provider: ${{ matrix.cache_provider }}
       - name: Install dist
         run: ${{ matrix.install_dist.run }}
       # Get the dist-manifest

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -18,20 +18,17 @@ concurrency:
 
 jobs:
   nextest:
-    runs-on: ${{matrix.os}}
+    runs-on: ${{matrix.large_runner}}
     strategy:
       matrix: &matrix
         build: [linux, macos, windows]
         include:
-          - build: linux
-            os: ubuntu-latest
-            target: x86_64-unknown-linux-musl
-          - build: macos
-            os: macos-latest
-            target: x86_64-apple-darwin
-          - build: windows
-            os: windows-latest
-            target: x86_64-pc-windows-msvc
+          - runner: ubuntu-latest
+            large_runner: blacksmith-4vcpu-ubuntu-2404
+          - runner: macos-latest
+            large_runner: blacksmith-6vcpu-macos-26
+          - runner: windows-latest
+            large_runner: blacksmith-8vcpu-windows-2025
     permissions:
       contents: read
     steps:
@@ -153,7 +150,7 @@ jobs:
         uses: actions/deploy-pages@v5
 
   clippy:
-    runs-on: ${{matrix.os}}
+    runs-on: ${{matrix.runner}}
     strategy:
       matrix: *matrix
     steps:
@@ -164,7 +161,7 @@ jobs:
         run: cargo clippy
 
   rustfmt:
-    runs-on: ${{matrix.os}}
+    runs-on: ${{matrix.runner}}
     strategy:
       matrix: *matrix
     steps:
@@ -175,7 +172,7 @@ jobs:
           cargo fmt --all -- --check
 
   clippy-no-default-features:
-    runs-on: ${{matrix.os}}
+    runs-on: ${{matrix.runner}}
     strategy:
       matrix: *matrix
     steps:
@@ -205,7 +202,7 @@ jobs:
   fuzz:
     permissions:
       contents: read
-    runs-on: ${{matrix.os}}
+    runs-on: ${{matrix.runner}}
     strategy:
       matrix: *matrix
     steps:
@@ -249,7 +246,7 @@ jobs:
         if: failure()
         uses: actions/upload-artifact@v4
         with:
-          name: fuzz-crashes-${{ matrix.build }}
+          name: fuzz-crashes-${{ runner.os }}
           path: fuzz/artifacts/
           if-no-files-found: ignore
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -90,8 +90,6 @@ jobs:
 
   coverage:
     runs-on: ubuntu-latest
-    permissions:
-      code-quality: write
     steps:
       - *linux-deps
       - *checkout
@@ -111,15 +109,6 @@ jobs:
         env:
           LC_ALL: en_US.UTF-8
           TERM: xterm-256color
-      - name: "Upload coverage report"
-        if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository
-        continue-on-error: true
-        uses: actions/upload-code-coverage@v1
-        with:
-          file: coverage.xml
-          language: Rust
-          label: ${{ runner.os }}
-
       - name: "Generate coverage badge"
         if: &if-master github.ref == format('refs/heads/{0}', github.event.repository.default_branch)
         uses: emibcn/badge-action@v2.0.4

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -24,11 +24,11 @@ jobs:
         build: [linux, macos, windows]
         include:
           - runner: ubuntu-latest
-            large_runner: blacksmith-4vcpu-ubuntu-2404
+            large_runner: blacksmith-2vcpu-ubuntu-2404
           - runner: macos-latest
             large_runner: blacksmith-6vcpu-macos-26
           - runner: windows-latest
-            large_runner: blacksmith-8vcpu-windows-2025
+            large_runner: blacksmith-4vcpu-windows-2025
     permissions:
       contents: read
     steps:

--- a/.github/workflows/winget.yml
+++ b/.github/workflows/winget.yml
@@ -5,9 +5,11 @@ name: Publish to winget
 # Windows Package Manager Community Repository (microsoft/winget-pkgs) using the
 # Windows .zip artifact that dist already builds and attaches to the release.
 #
-# Requires a `WINGET_TOKEN` repository secret: a GitHub PAT with the
+# Requires a `WINGET_TOKEN` repository secret: a *classic* GitHub PAT with the
 # `public_repo` scope that owns a fork of microsoft/winget-pkgs under the
-# `fork-user` account (see below). Without it the job fails at submission time.
+# `fork-user` account (see below). Fine-grained tokens are not supported -- they
+# can commit but cannot open the cross-fork PR to winget-pkgs. Without it the job
+# fails at submission time.
 on:
   workflow_call:
     inputs:

--- a/.github/workflows/winget.yml
+++ b/.github/workflows/winget.yml
@@ -1,0 +1,32 @@
+name: Publish to winget
+
+# Custom dist publish job (wired in through `publish-jobs` in dist-workspace.toml).
+# After dist creates the GitHub Release, this submits the new version to the
+# Windows Package Manager Community Repository (microsoft/winget-pkgs) using the
+# Windows .zip artifact that dist already builds and attaches to the release.
+#
+# Requires a `WINGET_TOKEN` repository secret: a GitHub PAT with the
+# `public_repo` scope that owns a fork of microsoft/winget-pkgs under the
+# `fork-user` account (see below). Without it the job fails at submission time.
+on:
+  workflow_call:
+    inputs:
+      plan:
+        required: true
+        type: string
+
+jobs:
+  winget:
+    name: Publish winget package
+    # winget-pkgs only accepts stable versions; never submit prereleases.
+    if: ${{ !fromJson(inputs.plan).announcement_is_prerelease }}
+    runs-on: ubuntu-latest
+    steps:
+      - name: Submit skim to the Windows Package Manager Community Repository
+        uses: vedantmgoyal9/winget-releaser@v2
+        with:
+          identifier: skim-rs.skim
+          installers-regex: '-pc-windows-msvc\.zip$'
+          release-tag: ${{ fromJson(inputs.plan).announcement_tag }}
+          fork-user: skim-rs
+          token: ${{ secrets.WINGET_TOKEN }}

--- a/.github/workflows/winget.yml
+++ b/.github/workflows/winget.yml
@@ -14,6 +14,10 @@ on:
       plan:
         required: true
         type: string
+    secrets:
+      WINGET_TOKEN:
+        required: true
+        description: "GitHub PAT with public_repo scope for winget-pkgs PR"
 
 jobs:
   winget:

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -154,7 +154,6 @@ extended-description = "skim is a general purpose fuzzy finder written in Rust, 
 assets = [
     ["target/release/sk", "usr/bin/", "755"],
     ["man/man1/sk.1", "usr/share/man/man1/", "644"],
-    ["man/man1/sk-tmux.1", "usr/share/man/man1/", "644"],
     ["shell/completion.bash", "usr/share/bash-completion/completions/sk", "644"],
     ["shell/completion.zsh", "usr/share/zsh/vendor-completions/_sk", "644"],
     ["shell/completion.fish", "usr/share/fish/vendor_completions.d/sk.fish", "644"],
@@ -167,7 +166,6 @@ assets = [
 assets = [
     { source = "target/release/sk", dest = "/usr/bin/sk", mode = "755" },
     { source = "man/man1/sk.1", dest = "/usr/share/man/man1/sk.1", mode = "644", doc = true },
-    { source = "man/man1/sk-tmux.1", dest = "/usr/share/man/man1/sk-tmux.1", mode = "644", doc = true },
     { source = "shell/completion.bash", dest = "/usr/share/bash-completion/completions/sk", mode = "644" },
     { source = "shell/completion.zsh", dest = "/usr/share/zsh/site-functions/_sk", mode = "644" },
     { source = "shell/completion.fish", dest = "/usr/share/fish/vendor_completions.d/sk.fish", mode = "644" },

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -142,3 +142,35 @@ upgrade-guid = "6DDAED06-EBE2-41C4-94F5-CB03F2A4B92E"
 path-guid = "05D1A327-19E0-4C82-B5EC-6B28E40C691B"
 license = false
 eula = false
+
+# Debian package (.deb) built via `cargo deb`.
+# Ships the `sk` executable, the man pages and the shell completions.
+[package.metadata.deb]
+maintainer = "Loric ANDRE, Zhang Jinzhou <lotabout@gmail.com>"
+copyright = "The skim developers"
+section = "utils"
+priority = "optional"
+extended-description = "skim is a general purpose fuzzy finder written in Rust, usable as a command line tool and as a library."
+assets = [
+    ["target/release/sk", "usr/bin/", "755"],
+    ["man/man1/sk.1", "usr/share/man/man1/", "644"],
+    ["man/man1/sk-tmux.1", "usr/share/man/man1/", "644"],
+    ["shell/completion.bash", "usr/share/bash-completion/completions/sk", "644"],
+    ["shell/completion.zsh", "usr/share/zsh/vendor-completions/_sk", "644"],
+    ["shell/completion.fish", "usr/share/fish/vendor_completions.d/sk.fish", "644"],
+    ["README.md", "usr/share/doc/skim/README.md", "644"],
+]
+
+# RPM package (.rpm) built via `cargo generate-rpm`.
+# Ships the `sk` executable, the man pages and the shell completions.
+[package.metadata.generate-rpm]
+assets = [
+    { source = "target/release/sk", dest = "/usr/bin/sk", mode = "755" },
+    { source = "man/man1/sk.1", dest = "/usr/share/man/man1/sk.1", mode = "644", doc = true },
+    { source = "man/man1/sk-tmux.1", dest = "/usr/share/man/man1/sk-tmux.1", mode = "644", doc = true },
+    { source = "shell/completion.bash", dest = "/usr/share/bash-completion/completions/sk", mode = "644" },
+    { source = "shell/completion.zsh", dest = "/usr/share/zsh/site-functions/_sk", mode = "644" },
+    { source = "shell/completion.fish", dest = "/usr/share/fish/vendor_completions.d/sk.fish", mode = "644" },
+    { source = "README.md", dest = "/usr/share/doc/skim/README.md", mode = "644", doc = true },
+    { source = "LICENSE", dest = "/usr/share/doc/skim/LICENSE", mode = "644", doc = true },
+]

--- a/README.md
+++ b/README.md
@@ -91,6 +91,10 @@ The skim project contains several components:
 | Gentoo         | Portage           | `emerge --ask app-misc/skim` |
 | Guix           | guix              | `guix install skim`          |
 | Void           | XBPS              | `xbps-install -S skim`       |
+| Windows        | winget            | `winget install skim-rs.skim`|
+| Windows        | Scoop             | `scoop install skim`         |
+| Debian/Ubuntu  | `.deb` package    |   see below                  |
+| Fedora/RHEL/SUSE | `.rpm` package  |   see below                  |
 
 <a href="https://repology.org/project/skim-fuzzy-finder/versions">
     <img src="https://repology.org/badge/vertical-allrepos/skim-fuzzy-finder.svg?columns=4" alt="Packaging status">
@@ -101,6 +105,31 @@ Up to date Fedora packages are provided via an unofficial community-maintained C
 ```bash
 sudo dnf copr enable sisyphus1813/skim
 sudo dnf install skim
+```
+
+### Windows
+Using [winget](https://learn.microsoft.com/windows/package-manager/):
+```powershell
+winget install skim-rs.skim
+```
+Or using [Scoop](https://scoop.sh/):
+```powershell
+scoop install skim
+```
+
+### Debian and RPM packages
+Every [release](https://github.com/skim-rs/skim/releases/latest) ships prebuilt
+`.deb` and `.rpm` packages for `amd64` and `arm64`. Each one installs the `sk`
+executable, its man page and the bash/zsh/fish completions.
+
+Download the package matching your distribution and architecture from the
+[latest release](https://github.com/skim-rs/skim/releases/latest), then install it:
+```sh
+# Debian / Ubuntu (use skim_*_arm64.deb on ARM machines)
+sudo dpkg -i skim_*_amd64.deb
+
+# Fedora / RHEL / openSUSE (use skim-*.aarch64.rpm on ARM machines)
+sudo rpm -i skim-*.x86_64.rpm
 ```
 
 

--- a/README.md
+++ b/README.md
@@ -91,7 +91,7 @@ The skim project contains several components:
 | Gentoo         | Portage           | `emerge --ask app-misc/skim` |
 | Guix           | guix              | `guix install skim`          |
 | Void           | XBPS              | `xbps-install -S skim`       |
-| Windows        | winget            | `winget install skim-rs.skim`|
+| Windows        | winget            | `winget install skim`|
 | Windows        | Scoop             | `scoop install skim`         |
 | Debian/Ubuntu  | `.deb` package    |   see below                  |
 | Fedora/RHEL/SUSE | `.rpm` package  |   see below                  |
@@ -110,7 +110,7 @@ sudo dnf install skim
 ### Windows
 Using [winget](https://learn.microsoft.com/windows/package-manager/):
 ```powershell
-winget install skim-rs.skim
+winget install skim
 ```
 Or using [Scoop](https://scoop.sh/):
 ```powershell

--- a/dist-workspace.toml
+++ b/dist-workspace.toml
@@ -25,7 +25,7 @@ plan-jobs = ["./test"]
 # Extra build jobs to run in CI (build the .deb and .rpm packages)
 global-artifacts-jobs = ["./package"]
 # Publish jobs to run in CI
-publish-jobs = ["./publish"]
+publish-jobs = ["./publish", "./winget"]
 # Whether to publish prereleases to package managers
 publish-prereleases = true
 

--- a/dist-workspace.toml
+++ b/dist-workspace.toml
@@ -15,6 +15,9 @@ targets = ["aarch64-apple-darwin", "aarch64-unknown-linux-gnu", "aarch64-unknown
 install-path = "CARGO_HOME"
 # Whether to install an updater program
 install-updater = false
+# TEMPORARY: build & upload artifacts on PRs so the .deb/.rpm can be verified.
+# Revert to the default (remove this line) before merging.
+pr-run-mode = "upload"
 # Extra static files to include in each App (path relative to this Cargo.toml's dir)
 include = ["./man/", "./shell/"]
 # Plan jobs to run in CI

--- a/dist-workspace.toml
+++ b/dist-workspace.toml
@@ -19,6 +19,8 @@ install-updater = false
 include = ["./man/", "./shell/"]
 # Plan jobs to run in CI
 plan-jobs = ["./test"]
+# Extra build jobs to run in CI (build the .deb and .rpm packages)
+global-artifacts-jobs = ["./package"]
 # Publish jobs to run in CI
 publish-jobs = ["./publish"]
 # Whether to publish prereleases to package managers

--- a/dist-workspace.toml
+++ b/dist-workspace.toml
@@ -4,7 +4,7 @@ members = ["cargo:."]
 # Config for 'dist'
 [dist]
 # The preferred dist version to use in CI (Cargo.toml SemVer syntax)
-cargo-dist-version = "0.30.4"
+cargo-dist-version = "0.32.0"
 # CI backends to support
 ci = "github"
 # The installers to generate for each app
@@ -15,14 +15,11 @@ targets = ["aarch64-apple-darwin", "aarch64-unknown-linux-gnu", "aarch64-unknown
 install-path = "CARGO_HOME"
 # Whether to install an updater program
 install-updater = false
-# TEMPORARY: build & upload artifacts on PRs so the .deb/.rpm can be verified.
-# Revert to the default (remove this line) before merging.
-pr-run-mode = "upload"
 # Extra static files to include in each App (path relative to this Cargo.toml's dir)
 include = ["./man/", "./shell/"]
 # Plan jobs to run in CI
 plan-jobs = ["./test"]
-# Extra build jobs to run in CI (build the .deb and .rpm packages)
+# Global artifacts jobs to run in CI
 global-artifacts-jobs = ["./package"]
 # Publish jobs to run in CI
 publish-jobs = ["./publish", "./winget"]
@@ -30,7 +27,6 @@ publish-jobs = ["./publish", "./winget"]
 publish-prereleases = true
 
 [dist.github-custom-job-permissions.test]
-code-quality = "write"
 contents = "read"
 pages = "write"
 id-token = "write"

--- a/fuzz/Cargo.lock
+++ b/fuzz/Cargo.lock
@@ -3,21 +3,6 @@
 version = 4
 
 [[package]]
-name = "addr2line"
-version = "0.25.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1b5d307320b3181d6d7954e663bd7c774a838b8220fe0593c86d9fb09f498b4b"
-dependencies = [
- "gimli",
-]
-
-[[package]]
-name = "adler2"
-version = "2.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
-
-[[package]]
 name = "aho-corasick"
 version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -95,21 +80,6 @@ name = "autocfg"
 version = "1.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f2032f911046de80f0a198e0901378627c33f59ea0ac00e363d481118bd70a53"
-
-[[package]]
-name = "backtrace"
-version = "0.3.76"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bb531853791a215d7c62a30daf0dde835f381ab5de4589cfe7c649d2cbe92bd6"
-dependencies = [
- "addr2line",
- "cfg-if",
- "libc",
- "miniz_oxide",
- "object",
- "rustc-demangle",
- "windows-link",
-]
 
 [[package]]
 name = "base64"
@@ -226,33 +196,6 @@ name = "cfg_aliases"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
-
-[[package]]
-name = "color-eyre"
-version = "0.6.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e5920befb47832a6d61ee3a3a846565cfa39b331331e68a3b1d1116630f2f26d"
-dependencies = [
- "backtrace",
- "color-spantrace",
- "eyre",
- "indenter",
- "once_cell",
- "owo-colors",
- "tracing-error",
-]
-
-[[package]]
-name = "color-spantrace"
-version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b8b88ea9df13354b55bc7234ebcce36e6ef896aca2e42a15de9e10edce01b427"
-dependencies = [
- "once_cell",
- "owo-colors",
- "tracing-core",
- "tracing-error",
-]
 
 [[package]]
 name = "compact_str"
@@ -739,12 +682,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "gimli"
-version = "0.32.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e629b9b98ef3dd8afe6ca2bd0f89306cec16d43d907889945bc5d6687f2f13c7"
-
-[[package]]
 name = "hashbrown"
 version = "0.16.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1015,15 +952,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "68354c5c6bd36d73ff3feceb05efa59b6acb7626617f4962be322a825e61f79a"
 
 [[package]]
-name = "miniz_oxide"
-version = "0.8.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1fa76a2c86f704bdb222d66965fb3d63269ce38518b83cb0575fca855ebb6316"
-dependencies = [
- "adler2",
-]
-
-[[package]]
 name = "mio"
 version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1127,15 +1055,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "object"
-version = "0.37.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ff76201f031d8863c38aa7f905eca4f53abbfa15f609db4277d44cd8938f33fe"
-dependencies = [
- "memchr",
-]
-
-[[package]]
 name = "once_cell"
 version = "1.21.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1149,12 +1068,6 @@ checksum = "7bb71e1b3fa6ca1c61f383464aaf2bb0e2f8e772a1f01d486832464de363b951"
 dependencies = [
  "num-traits",
 ]
-
-[[package]]
-name = "owo-colors"
-version = "4.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d211803b9b6b570f68772237e415a029d5a50c65d382910b879fb19d3271f94d"
 
 [[package]]
 name = "palette"
@@ -1527,12 +1440,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "323c417e1d9665a65b263ec744ba09030cfb277e9daa0b018a4ab62e57bc8189"
 
 [[package]]
-name = "rustc-demangle"
-version = "0.1.27"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b50b8869d9fc858ce7266cce0194bd74df58b9d0e3f6df3a9fc8eb470d95c09d"
-
-[[package]]
 name = "rustc_version"
 version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1631,15 +1538,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "sharded-slab"
-version = "0.1.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f40ca3c46823713e0d4209592e8d6e826aa57e928f09752619fc696c499637f6"
-dependencies = [
- "lazy_static",
-]
-
-[[package]]
 name = "shared_library"
 version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1715,14 +1613,14 @@ checksum = "8ee5873ec9cce0195efcb7a4e9507a04cd49aec9c83d0389df45b1ef7ba2e649"
 
 [[package]]
 name = "skim"
-version = "5.0.0"
+version = "5.3.1"
 dependencies = [
  "ansi-to-tui",
  "assert_enum_variants",
- "color-eyre",
  "crossterm",
  "derive_builder",
  "derive_more",
+ "eyre",
  "futures",
  "indexmap",
  "kanal",
@@ -2046,47 +1944,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "tracing"
-version = "0.1.44"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "63e71662fa4b2a2c3a26f570f037eb95bb1f85397f3cd8076caed2f026a6d100"
-dependencies = [
- "pin-project-lite",
- "tracing-core",
-]
-
-[[package]]
-name = "tracing-core"
-version = "0.1.36"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "db97caf9d906fbde555dd62fa95ddba9eecfd14cb388e4f491a66d74cd5fb79a"
-dependencies = [
- "once_cell",
- "valuable",
-]
-
-[[package]]
-name = "tracing-error"
-version = "0.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8b1581020d7a273442f5b45074a6a57d5757ad0a47dac0e9f0bd57b81936f3db"
-dependencies = [
- "tracing",
- "tracing-subscriber",
-]
-
-[[package]]
-name = "tracing-subscriber"
-version = "0.3.23"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cb7f578e5945fb242538965c2d0b04418d38ec25c79d160cd279bf0731c8d319"
-dependencies = [
- "sharded-slab",
- "thread_local",
- "tracing-core",
-]
-
-[[package]]
 name = "tui-term"
 version = "0.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2179,12 +2036,6 @@ dependencies = [
  "js-sys",
  "wasm-bindgen",
 ]
-
-[[package]]
-name = "valuable"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ba73ea9cf16a25df0c8caa16c51acb937d5712a8429db78a3ee29d5dcacd3a65"
 
 [[package]]
 name = "version_check"


### PR DESCRIPTION
## Checklist

- [x] The title of my PR follows [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] I have updated the documentation (`README.md`, comments, `src/manpage.rs` and/or `src/options.rs` if applicable) — n/a, CI/packaging only
- [ ] I have added unit tests — n/a, CI/packaging only
- [ ] I have added [integration tests](https://github.com/skim-rs/skim/tree/master/tests) — n/a, CI/packaging only
- [x] I have linked all related issues or PRs

## Description of the changes

Adds Linux `.deb`/`.rpm` packages and winget publishing to the release pipeline.

Everything is driven through **dist** config in `dist-workspace.toml`; `release.yml`
is regenerated with `dist generate` and is never hand-edited.

### `.deb` / `.rpm` (amd64 + arm64)

`dist` (cargo-dist) 0.30.4 has no native deb/rpm installer, so the packages are
produced by a **custom dist build job** (`global-artifacts-jobs = ["./package"]`):

- `Cargo.toml` — `[package.metadata.deb]` (cargo-deb) and
  `[package.metadata.generate-rpm]` (cargo-generate-rpm) describe the payload:
  the `sk` executable, the `sk.1` man page, and the bash/zsh/fish completions
  (plus README/LICENSE docs).
- `.github/workflows/package.yml` — a matrix that builds **natively** for amd64
  (`ubuntu-22.04`) and arm64 (`ubuntu-22.04-arm`), so skim's C-linking deps don't
  need cross-compilation. Packaging tools are installed via
  `taiki-e/install-action` + `Swatinem/rust-cache`, matching the `test.yml`
  convention. A guard step consumes the dist `plan` and fails the build if the
  crate version doesn't match the planned release version.
- Each arch uploads under `artifacts-linux-packages-<arch>`, so dist's `host`
  job attaches all four packages to the GitHub Release.

The amd64 packages were built and inspected locally; the arm64 leg builds for the
first time on CI (this PR temporarily enables PR artifact builds — see below).

### winget (Windows Package Manager)

`.github/workflows/winget.yml`, wired in as a dist **publish job**
(`publish-jobs = [..., "./winget"]`). After the release is created it submits the
new version to `microsoft/winget-pkgs` via `vedantmgoyal9/winget-releaser`, using
the Windows `.zip` artifact dist already attaches. Uses the identifier and
installer regex from #769:

```yml
identifier: skim-rs.skim
installers-regex: '-pc-windows-msvc\.zip$'
```

Prereleases are never submitted.

> [!IMPORTANT]
> The winget job needs a **`WINGET_TOKEN`** repository secret: a GitHub PAT with
> the `public_repo` scope whose account owns a fork of `microsoft/winget-pkgs`
> (currently configured as `fork-user: skim-rs`). Without it the job fails at
> submission time.

### ⚠️ Temporary change to revert before merge

`dist-workspace.toml` sets `pr-run-mode = "upload"` so CI builds and uploads the
`.deb`/`.rpm` (and other release artifacts) on this PR, downloadable from the
workflow run for verification. **Remove that line before merging** so PRs go back
to plan-only. (The winget job is publish-only and does not run on PRs.)

Refs #769

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added Linux distribution packaging to produce `.deb` and `.rpm` artifacts (including binary, man page, shell completions, and README).
  - Added automated winget publishing for non-prerelease announcements.

- **Release Improvements**
  - Integrated package generation and winget publishing into the release pipeline with appropriate gating and completion checks.
  - Improved build efficiency by caching Rust dependencies during artifact builds.

- **CI**
  - Enabled temporary pull request artifact uploads to validate generated package outputs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->