### PR TITLE
fix(field): an out-of-range field index silently matches field 1

### DIFF
--- a/src/field.rs
+++ b/src/field.rs
@@ -23,6 +23,14 @@ pub enum FieldRange {
     Both(i32, i32),
 }
 
+/// Parses one side of a field range. The regex only ever hands us `-?\d+`, so the
+/// single failure mode is overflowing `i32`; saturate instead of silently falling
+/// back to a different field.
+fn parse_index(s: &str) -> i32 {
+    s.parse()
+        .unwrap_or(if s.starts_with('-') { i32::MIN } else { i32::MAX })
+}
+
 impl FieldRange {
     /// Parses a field range from a string (e.g., "1", "1..", "..10", "1..10")
     #[allow(clippy::should_implement_trait)]
@@ -32,8 +40,8 @@ impl FieldRange {
         // "1", "1..", "..10", "1..10", etc.
         let opt_caps = FIELD_RANGE.captures(range);
         if let Some(caps) = opt_caps {
-            let opt_left = caps.name("left").map(|s| s.as_str().parse().unwrap_or(1));
-            let opt_right = caps.name("right").map(|s| s.as_str().parse().unwrap_or(-1));
+            let opt_left = caps.name("left").map(|s| parse_index(s.as_str()));
+            let opt_right = caps.name("right").map(|s| parse_index(s.as_str()));
             let opt_sep = caps.name("sep").map(|s| s.as_str().to_string());
 
             match (opt_left, opt_right) {

--- a/src/field_tests.rs
+++ b/src/field_tests.rs
@@ -19,6 +19,24 @@ fn test_parse_range() {
     assert_eq!(FieldRange::from_str("a..b"), None);
 }
 
+#[test]
+fn test_parse_range_out_of_i32_range() {
+    // Indices past i32 saturate instead of silently falling back to field 1 / -1.
+    assert_eq!(FieldRange::from_str("2147483648"), Some(Single(i32::MAX)));
+    assert_eq!(FieldRange::from_str("-2147483649"), Some(Single(i32::MIN)));
+    assert_eq!(FieldRange::from_str("99999999999.."), Some(RightInf(i32::MAX)));
+    assert_eq!(FieldRange::from_str("..99999999999"), Some(LeftInf(i32::MAX)));
+    assert_eq!(FieldRange::from_str("2..99999999999"), Some(Both(2, i32::MAX)));
+
+    // ...and a saturated index still resolves to nothing on a short line.
+    assert_eq!(
+        FieldRange::from_str("2147483648").unwrap().to_index_pair(3),
+        Single(i32::MAX).to_index_pair(3)
+    );
+    assert_eq!(FieldRange::from_str("2147483648").unwrap().to_index_pair(3), None);
+    assert_eq!(FieldRange::from_str("-2147483649").unwrap().to_index_pair(3), None);
+}
+
 use regex::Regex;
 
 #[test]

--- a/tests/cli.rs
+++ b/tests/cli.rs
@@ -151,11 +151,14 @@ fn nth_index_past_i32_does_not_fall_back_to_field_1() {
     assert_eq!(code_huge, Some(1), "an out-of-range field must match nothing");
     assert!(out_huge.is_empty());
 
-    // Same for the `{N}` field syntax in --output-format.
-    let (_, out_huge, _) = run_sk_argv("a b c", &["-1", "-q", "a", "--output-format", "{2147483648}"], &[]);
-    let (_, out_neg, _) = run_sk_argv("a b c", &["-1", "-q", "a", "--output-format", "{-2147483649}"], &[]);
-    assert_eq!(out_huge.trim_end(), "");
-    assert_eq!(out_neg.trim_end(), "");
+    // Same for the `{N}` field syntax in --output-format. Assert the exit status and
+    // stderr too, so an empty stdout can't pass by way of the placeholder erroring out.
+    for placeholder in ["{2147483648}", "{-2147483649}"] {
+        let (code, out, err) = run_sk_argv("a b c", &["-1", "-q", "a", "--output-format", placeholder], &[]);
+        assert_eq!(code, Some(0), "{placeholder}: stderr: {err}");
+        assert_eq!(err, "", "{placeholder} should not error");
+        assert_eq!(out.trim_end(), "", "{placeholder} should render an empty field");
+    }
 }
 
 #[test]

--- a/tests/cli.rs
+++ b/tests/cli.rs
@@ -142,6 +142,23 @@ fn with_nth_accepts_space_separated_negative_index() {
 }
 
 #[test]
+fn nth_index_past_i32_does_not_fall_back_to_field_1() {
+    // An index too large for i32 used to fail to parse and silently become field 1,
+    // so `--nth <huge>` matched the first field instead of matching nothing.
+    let (code_huge, out_huge, _) = run_sk_argv("a b c", &["-f", "a", "--nth", "2147483648"], &[]);
+    let (code_oob, out_oob, _) = run_sk_argv("a b c", &["-f", "a", "--nth", "5"], &[]);
+    assert_eq!((code_huge, out_huge.as_str()), (code_oob, out_oob.as_str()));
+    assert_eq!(code_huge, Some(1), "an out-of-range field must match nothing");
+    assert!(out_huge.is_empty());
+
+    // Same for the `{N}` field syntax in --output-format.
+    let (_, out_huge, _) = run_sk_argv("a b c", &["-1", "-q", "a", "--output-format", "{2147483648}"], &[]);
+    let (_, out_neg, _) = run_sk_argv("a b c", &["-1", "-q", "a", "--output-format", "{-2147483649}"], &[]);
+    assert_eq!(out_huge.trim_end(), "");
+    assert_eq!(out_neg.trim_end(), "");
+}
+
+#[test]
 fn select_1_with_output_format() {
     // --output-format renders the selected item through the printf branch.
     let (code, stdout, _) = run_sk("1\\n2\\n3", "--select-1 -q 3 --output-format '{}'");


### PR DESCRIPTION
## Checklist

- [x] The title of my PR follows [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/)
- [ ] I have updated the documentation (`README.md`, comments, `src/manpage.rs` and/or `src/options.rs` if applicable). No doc change needed: the documented behaviour is unchanged, this makes the code match it.
- [x] I have added unit tests
- [x] I have added [integration tests](https://github.com/skim-rs/skim/tree/master/tests)
- [ ] I have linked all related issues or PRs. None found.

## Description of the changes

A field index too large for `i32` silently becomes field 1, so `--nth` matches the wrong field instead of matching nothing.

```
                          before          after
--nth 2147483648 -f a     rc=0 "a b c"    rc=1 ""
--nth 5 -f a              rc=1 ""         rc=1 ""
```

The `--nth 5` line is the control: it is what an out-of-range index already does correctly on a three-field line. Before this change the huge index disagreed with it, after it they match.

Same through the `{N}` syntax in `--output-format`:

```
--output-format {2147483648}     before: [a]     after: []
--output-format {-2147483649}    before: [a]     after: []
```

### Cause

`FieldRange::from_str` parsed each side with `unwrap_or(1)` and `unwrap_or(-1)`:

```rust
let opt_left = caps.name("left").map(|s| s.as_str().parse().unwrap_or(1));
let opt_right = caps.name("right").map(|s| s.as_str().parse().unwrap_or(-1));
```

The regex only ever passes `-?\d+`, so the one reachable failure is `i32` overflow, and the fallback quietly redirects the request to a completely different field. A user asking for a field that cannot exist gets field 1's contents rather than nothing.

### The fix

Saturate to `i32::MAX` or `i32::MIN` depending on the sign, in a small `parse_index` helper used by both sides. An index past the end of the line then resolves to nothing, which is what any other out-of-range index already does.

This affects `--nth`, `--with-nth`, `--hide-nth` and `{N}` in `--output-format`, all of which route through `FieldRange::from_str`.

### Tests

`test_parse_range_out_of_i32_range` in `src/field_tests.rs` covers all four range shapes plus `to_index_pair` on a short line, so it pins that saturation resolves to nothing rather than just that it parses.

`nth_index_past_i32_does_not_fall_back_to_field_1` in `tests/cli.rs` asserts the huge index and the plain out-of-range index produce identical exit code and output, and covers the `--output-format` path.

Reverting `field.rs` fails both:

```
test_parse_range_out_of_i32_range
  left: Some(Single(1))   right: Some(Single(2147483647))

nth_index_past_i32_does_not_fall_back_to_field_1
  left: (Some(0), "a b c\n")   right: (Some(1), "")
```

### Gates

`cargo nextest run --lib --test cli` is 867 passed, 0 failed. `cargo clippy --all-targets` and `cargo +nightly fmt --check` are both clean.

The Zellij-backed interactive suite could not run here, since there is no `zellij` binary on this machine. That is why the integration test went in `tests/cli.rs`, the non-interactive suite that spawns a real `sk` without a TTY, so the new coverage does execute rather than being skipped.

*Disclosure: written with AI assistance (Claude Code), which the "Vibe Coding" section of CONTRIBUTING treats as my own code. I built both binaries from this tree, produced every before and after above by running them, and ran the revert check myself.*


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected handling of field indices that exceed supported numeric limits.
  * Oversized positive and negative indices now safely saturate and produce no unintended matches or output.
  * Prevented invalid indices from falling back to the first field.
  * Command-line field selection now handles excessively large indices consistently without errors.

* **Tests**
  * Added coverage for oversized indices in field ranges and command-line options.
  * Verified bounded and unbounded ranges return empty results when indices exceed available fields.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->