### PR TITLE
fix(options): --with-nth rejects a space-separated negative index

### DIFF
--- a/src/options.rs
+++ b/src/options.rs
@@ -196,7 +196,13 @@ pub struct SkimOptions {
     /// See **nth** for the details
     #[cfg_attr(
         feature = "cli",
-        arg(long, default_value = "", help_heading = "Search", value_delimiter = ',')
+        arg(
+            long,
+            default_value = "",
+            help_heading = "Search",
+            value_delimiter = ',',
+            allow_hyphen_values = true,
+        )
     )]
     pub with_nth: Vec<String>,
 

--- a/src/options_tests.rs
+++ b/src/options_tests.rs
@@ -2,6 +2,7 @@
 //! and history initialization, which apply defaults and cross-option rules.
 
 use super::*;
+use crate::field::FieldRange;
 use crate::item::RankCriteria;
 use crate::tui::statusline::InfoDisplay;
 
@@ -286,4 +287,39 @@ fn build_history_file_adds_history_keybindings() {
     );
 
     let _ = std::fs::remove_file(&qpath);
+}
+
+/// Helper: parse real CLI args with no env influence.
+fn parse_args(args: &[&str]) -> Result<SkimOptions, clap::Error> {
+    SkimOptions::merge_args_and_parse(
+        "sk".to_string(),
+        None,
+        None,
+        args.iter().map(|s| (*s).to_string()),
+        None,
+    )
+}
+
+#[test]
+fn negative_field_indices_parse_for_every_nth_flag() {
+    // All three flags document the same `nth` syntax, which includes `-1` for the
+    // last field; a space-separated negative value must not be read as a flag.
+    for flag in ["--nth", "--with-nth", "--hide-nth"] {
+        let opts = parse_args(&[flag, "-1"]).unwrap_or_else(|e| panic!("{flag} -1 failed to parse: {e}"));
+        let got = match flag {
+            "--nth" => &opts.nth,
+            "--with-nth" => &opts.with_nth,
+            _ => &opts.hide_nth,
+        };
+        assert_eq!(got, &vec!["-1".to_string()], "{flag}");
+        assert_eq!(
+            FieldRange::from_str(&got[0]),
+            Some(FieldRange::Single(-1)),
+            "{flag} should resolve to the last field"
+        );
+    }
+
+    // ...and a negative index inside a comma-separated list.
+    let opts = parse_args(&["--with-nth", "2,-1"]).expect("--with-nth 2,-1 should parse");
+    assert_eq!(opts.with_nth, vec!["2".to_string(), "-1".to_string()]);
 }

--- a/tests/cli.rs
+++ b/tests/cli.rs
@@ -129,6 +129,19 @@ fn filter_mode_no_sort_preserves_input_order() {
 }
 
 #[test]
+fn with_nth_accepts_space_separated_negative_index() {
+    // `--with-nth -1` (space form) used to be parsed as a missing value, while
+    // `--nth -1` and `--with-nth=-1` both worked.
+    let (code, stdout, stderr) = run_sk_argv("a b c", &["-f", "c", "--with-nth", "-1"], &[]);
+    assert_eq!(code, Some(0), "stderr: {stderr}");
+    assert_eq!(stdout.trim_end(), "a b c");
+
+    // The space form and the `=` form must agree.
+    let (code_eq, stdout_eq, _) = run_sk_argv("a b c", &["-f", "c", "--with-nth=-1"], &[]);
+    assert_eq!((code, stdout), (code_eq, stdout_eq));
+}
+
+#[test]
 fn select_1_with_output_format() {
     // --output-format renders the selected item through the printf branch.
     let (code, stdout, _) = run_sk("1\\n2\\n3", "--select-1 -q 3 --output-format '{}'");


### PR DESCRIPTION
## Checklist

- [x] The title of my PR follows [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/)
- [ ] I have updated the documentation (`README.md`, comments, `src/manpage.rs` and/or `src/options.rs` if applicable). No doc change needed: the docs already describe this behaviour, the parser did not implement it.
- [x] I have added unit tests
- [x] I have added [integration tests](https://github.com/skim-rs/skim/tree/master/tests)
- [ ] I have linked all related issues or PRs. None found.

## Description of the changes

`--with-nth -1` is rejected, while `--nth -1` and `--with-nth=-1` both work.

```
                    before                                     after
--with-nth -1       error: a value is required for '--with-nth'  a b c
--with-nth -2       error: unexpected argument '-2' found        a b c
--with-nth=-1       a b c                                        a b c
--nth -1            a b c                                        a b c
```

`with_nth`'s own doc comment says "See **nth** for the details", and `nth`'s documentation lists `-1` as the last field. So the documented syntax is not accepted in its most natural spelling.

### Cause

`nth` and `hide_nth` both carry `allow_hyphen_values = true`; `with_nth` does not. Without it clap treats the `-1` as a flag rather than a value.

The repo's own tests encode the workaround: every existing negative `with-nth` snapshot test is written as `--with-nth=-1`, while the `hide-nth` ones are not constrained that way.

### The fix

Add `allow_hyphen_values = true` to `with_nth`, matching its two siblings.

### On the obvious risk

`allow_hyphen_values` can make clap swallow a following flag as a value, so I checked that before proposing it. On the **unpatched** binary:

```
--nth --print-query -f b        -> a b
--hide-nth --print-query -f b   -> a b
--with-nth --print-query -f b   -> error
```

The two flags that already have the attribute swallow `--print-query` today. After this change `--with-nth` behaves the same way. So this adopts the repo's existing convention rather than introducing a new hazard, but it is worth stating plainly rather than burying: the fix makes `--with-nth` consistent with a behaviour that is itself arguable. If you would rather remove the attribute from all three, that is a different and larger change and I am happy to open it separately.

### Tests

`negative_field_indices_parse_for_every_nth_flag` in `src/options_tests.rs` parses `-1` through all three flags and asserts each resolves to `FieldRange::Single(-1)`, plus a comma-separated `2,-1`. Covering all three rather than just the broken one is what makes it a consistency test instead of a regression test.

`with_nth_accepts_space_separated_negative_index` in `tests/cli.rs` covers the CLI end to end and asserts the space form and the `=` form agree.

Reverting `options.rs` fails both:

```
with_nth_accepts_space_separated_negative_index
  stderr: error: a value is required for '--with-nth <WITH_NTH>'
  left: Some(2)   right: Some(0)

negative_field_indices_parse_for_every_nth_flag
  fails on the --with-nth iteration
```

### Gates

`cargo nextest run --lib --test cli` is 867 passed, 0 failed. `cargo clippy --all-targets` and `cargo +nightly fmt --check` are clean.

The Zellij-backed interactive suite could not run here, since there is no `zellij` binary on this machine. The integration test went in `tests/cli.rs`, the non-interactive suite that spawns a real `sk` without a TTY, so the new coverage does execute.

*Disclosure: written with AI assistance (Claude Code), which the "Vibe Coding" section of CONTRIBUTING treats as my own code. I built both binaries from this tree, produced every before and after above by running them, and ran the revert check myself.*


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed `--with-nth` handling for negative field indices, including space-separated values such as `--with-nth -1`.
  * Preserved negative indices in comma-separated field lists.
  * Ensured `-1` correctly selects the last field.
  * Maintained the documented behavior and empty default for `--with-nth`.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->