### PR TITLE
fix(matcher): an inverse query only checks the first --nth field

### DIFF
--- a/src/engine/exact.rs
+++ b/src/engine/exact.rs
@@ -79,23 +79,32 @@ impl MatchEngine for ExactEngine {
         let mut matched_result = None;
         let item_text = item.text();
         let default_range = [(0, item_text.len())];
-        for &(start, end) in item.get_matching_ranges().unwrap_or(&default_range) {
-            let start = min(start, item_text.len());
-            let end = min(end, item_text.len());
-            if self.query_regex.is_none() {
-                matched_result = Some((0, 0));
-                break;
+        let ranges = item.get_matching_ranges().unwrap_or(&default_range);
+
+        if ranges.is_empty() {
+            // Nothing to match against (e.g. every `--nth` index is out of range): the item
+            // stays unmatched, inverse or not.
+        } else if self.query_regex.is_none() {
+            matched_result = Some((0, 0));
+        } else {
+            for &(start, end) in ranges {
+                let start = min(start, item_text.len());
+                let end = min(end, item_text.len());
+
+                matched_result =
+                    regex_match(&item_text[start..end], self.query_regex.as_ref()).map(|(s, e)| (s + start, e + start));
+
+                if matched_result.is_some() {
+                    break;
+                }
             }
 
-            matched_result =
-                regex_match(&item_text[start..end], self.query_regex.as_ref()).map(|(s, e)| (s + start, e + start));
-
+            // An inverse query has to be evaluated over *all* the matching ranges: the item
+            // only matches when none of them contains the query.  Inverting inside the loop
+            // would let the first non-matching field short-circuit the scan and wrongly
+            // accept an item whose later fields do contain the query.
             if self.inverse {
                 matched_result = matched_result.xor(Some((0, 0)));
-            }
-
-            if matched_result.is_some() {
-                break;
             }
         }
 

--- a/src/engine/exact_tests.rs
+++ b/src/engine/exact_tests.rs
@@ -83,6 +83,83 @@ fn inverse_match_excludes_query() {
     assert!(e.match_item(&"foo".to_string()).is_none());
 }
 
+/// An item exposing explicit matching ranges, as `--nth` produces.
+struct RangedItem {
+    text: String,
+    ranges: Vec<(usize, usize)>,
+}
+
+impl SkimItem for RangedItem {
+    fn text(&self) -> std::borrow::Cow<'_, str> {
+        std::borrow::Cow::Borrowed(&self.text)
+    }
+
+    fn get_matching_ranges(&self) -> Option<&[(usize, usize)]> {
+        Some(&self.ranges)
+    }
+}
+
+#[test]
+fn inverse_match_checks_every_matching_range() {
+    // `--nth 1,2` over "foo bar" yields two ranges: "foo" and "bar".  An inverse
+    // query `!foo` must reject the item because one of the ranges contains "foo",
+    // even though the *first* range scanned may not.
+    let e = engine(
+        "foo",
+        ExactMatchingParam {
+            inverse: true,
+            case: CaseMatching::Ignore,
+            ..Default::default()
+        },
+    );
+
+    let foo_in_first_range = RangedItem {
+        text: "foo bar".to_string(),
+        ranges: vec![(0, 3), (4, 7)],
+    };
+    assert!(
+        e.match_item(&foo_in_first_range).is_none(),
+        "item whose first field contains the query must not match an inverse query"
+    );
+
+    let foo_in_second_range = RangedItem {
+        text: "bar foo".to_string(),
+        ranges: vec![(0, 3), (4, 7)],
+    };
+    assert!(
+        e.match_item(&foo_in_second_range).is_none(),
+        "item whose second field contains the query must not match an inverse query"
+    );
+
+    let no_foo = RangedItem {
+        text: "bar baz".to_string(),
+        ranges: vec![(0, 3), (4, 7)],
+    };
+    assert!(
+        e.match_item(&no_foo).is_some(),
+        "item where no field contains the query must match an inverse query"
+    );
+}
+
+#[test]
+fn inverse_match_with_no_matching_range_does_not_match() {
+    // Every `--nth` index out of range leaves the item with no range at all;
+    // there is nothing to match against, so the item stays unmatched.
+    let e = engine(
+        "foo",
+        ExactMatchingParam {
+            inverse: true,
+            case: CaseMatching::Ignore,
+            ..Default::default()
+        },
+    );
+    let item = RangedItem {
+        text: "bar baz".to_string(),
+        ranges: vec![],
+    };
+    assert!(e.match_item(&item).is_none());
+}
+
 #[test]
 fn empty_query_matches_everything() {
     let e = engine("", ExactMatchingParam::default());

--- a/tests/cli.rs
+++ b/tests/cli.rs
@@ -111,6 +111,28 @@ fn filter_mode_with_print0() {
 }
 
 #[test]
+fn filter_mode_inverse_query_checks_every_nth_field() {
+    // `--nth 1,2` gives each item two matching ranges. An inverse query must
+    // reject an item when ANY of them contains the term, not just the first one.
+    let (code, stdout, _) = run_sk_argv("foo bar\nqux bar\n", &["-f", "!foo", "--nth", "1,2"], &[]);
+    assert_eq!(code, Some(0));
+    assert!(
+        !stdout.contains("foo bar"),
+        "!foo must exclude 'foo bar' (got {stdout:?})"
+    );
+    assert!(stdout.contains("qux bar"), "!foo must keep 'qux bar' (got {stdout:?})");
+
+    // The term sitting in the second field must be caught too.
+    let (code, stdout, _) = run_sk_argv("bar foo\nbar qux\n", &["-f", "!foo", "--nth", "1,2"], &[]);
+    assert_eq!(code, Some(0));
+    assert!(
+        !stdout.contains("bar foo"),
+        "!foo must exclude 'bar foo' (got {stdout:?})"
+    );
+    assert!(stdout.contains("bar qux"), "!foo must keep 'bar qux' (got {stdout:?})");
+}
+
+#[test]
 fn filter_mode_no_sort_preserves_input_order() {
     // Workers grab 4096-item chunks from a shared queue, so with enough items
     // each worker processes several chunks and the concatenation order of


### PR DESCRIPTION
With more than one `--nth` field, an inverse query accepts items it should
reject.

```
$ printf 'foo bar\nqux bar\n' | sk --filter '!foo' --nth 1,2
before:
foo bar
qux bar

after:
qux bar
```

The same query without `--nth` already printed only `qux bar`, so the two
disagree, and the `--nth` answer is the wrong one.

## Cause

`ExactEngine::match_item` inverts inside the loop over the matching ranges:

```rust
for &(start, end) in item.get_matching_ranges().unwrap_or(&default_range) {
    ...
    matched_result = regex_match(...);
    if self.inverse {
        matched_result = matched_result.xor(Some((0, 0)));
    }
    if matched_result.is_some() {
        break;
    }
}
```

For `!foo` against `foo bar` with `--nth 1,2`, field 2 is `bar`, which does not
contain `foo`, so the inversion turns it into a match and the loop breaks before
field 1 is ever considered. Any single field that lacks the term is enough to
accept the item.

## The fix

Scan the ranges first, looking for the term, and invert once afterwards. An
inverse query is a statement about the whole item, so it can only be decided once
every range has been looked at.

## Verification

`inverse_match_checks_every_matching_range` in `src/engine/exact_tests.rs`, plus
`filter_mode_inverse_query_checks_every_nth_field` in `tests/cli.rs` driving the
real binary.

Moving the `xor` back inside the loop fails the unit test:

```
thread 'engine::exact::tests::inverse_match_checks_every_matching_range' panicked at src/engine/exact_tests.rs:120:5:
item whose first field contains the query must not match an inverse query
test result: FAILED. 8 passed; 1 failed
```

Still correct after the change, each covered: positive queries, anchored inverse
(`!^foo`), AND-combined (`bar !foo`), and an out-of-range `--nth 5`.

`cargo test --lib` is 851 passed, `cargo test --test cli` is 21 passed.
`cargo clippy --all-targets` and `cargo +nightly fmt --check` are clean.

`cargo test --test execute` cannot run here: it needs `zellij >= 0.44` and only
tmux is available. That failure is pre-existing and unrelated.

## One design point worth confirming

An item where every `--nth` index is out of range now stays unmatched under an
inverse query. That is the same result as before, since the loop body simply
never ran, and it is consistent with the out-of-range field behaviour from #1155.
I pinned it with a unit test rather than leave it implicit, but say the word if
you would rather such an item matched.

## How I found it

Not from the tracker. I was reading `src/engine/exact.rs` and noticed the `xor`
sat inside the range loop while the `break` right after it made the loop
order-dependent. I then confirmed it with the real binary before writing
anything.

## Checklist

- [x] The title of my PR follows conventional commits
- [ ] I have updated the documentation (no doc change: this is a correctness fix, `--nth` and `!` are already documented as they now behave)
- [x] I have added unit tests
- [x] I have added integration tests
- [x] I have linked all related issues or PRs (none open for this)

*Disclosure: written with AI assistance (Claude Code). Per the Vibe Coding guidelines I treat it as my own: the before and after come from release binaries built from each tree, and I ran the mutation check myself.*


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved inverse filtering to correctly exclude items when a match appears in any selected range.
  * Empty matching ranges are now handled as unmatched, including for inverse queries.
  * Empty queries continue to match without unnecessary range processing.

* **Tests**
  * Added coverage for inverse matching across multiple fields and matching ranges.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->