### PR TITLE
ci: lock everything to make sure dependencies match

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -88,11 +88,11 @@ jobs:
           cache-all-crates: "true"
       - name: Generate files
         run: |
-          cargo run -- --man > ./man/man1/sk.1
-          cargo run -- --shell bash > ./shell/completion.bash
-          cargo run -- --shell zsh > ./shell/completion.zsh
-          cargo run -- --shell fish > ./shell/completion.fish
-          cargo run -- --shell nushell > ./shell/completion.nu
+          cargo run --locked -- --man > ./man/man1/sk.1
+          cargo run --locked -- --shell bash > ./shell/completion.bash
+          cargo run --locked -- --shell zsh > ./shell/completion.zsh
+          cargo run --locked -- --shell fish > ./shell/completion.fish
+          cargo run --locked -- --shell nushell > ./shell/completion.nu
       - name: Check diff
         run: |
           if git diff --exit-code; then

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -199,7 +199,7 @@ jobs:
       - *checkout
       - *toolchain
       - name: MSRV Verify
-        run: cargo +1.91.0 build --all-targets
+        run: cargo +1.91.0 build --release --locked --all-targets
 
   fuzz:
     permissions:
@@ -277,7 +277,7 @@ jobs:
         name: Fetch release tags
       - run: |
           latest_tag="$(git tag --list 'v*' --sort=-version:refname | head -n1)"
-          cargo public-api diff "${latest_tag}..HEAD" --deny removed --deny changed --omit blanket-impls,auto-trait-impls,auto-derived-impls
+          cargo public-api diff "${latest_tag}..HEAD" --deny removed --deny changed
         name: Run cargo-public-api
 
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -93,7 +93,7 @@ jobs:
         run: cargo test --doc
       - name: "Run tests"
         # Do not use `--all-targets` to avoid running benches
-        run: cargo nextest run --release --profile ci --bins --lib --examples --tests
+        run: cargo nextest run --release --locked --profile ci --bins --lib --examples --tests
         env:
           LC_ALL: en_US.UTF-8
           TERM: xterm-256color
@@ -130,7 +130,7 @@ jobs:
       - name: "Run tests with coverage"
         # Do not use `--all-targets` to avoid running benches
         run: |
-          cargo +nightly llvm-cov nextest --release --profile ci --branch --bins --lib --examples --tests --no-report
+          cargo +nightly llvm-cov nextest --locked --release --profile ci --branch --bins --lib --examples --tests --no-report
           cargo +nightly llvm-cov report --release --cobertura --output-path coverage.xml
           cargo +nightly llvm-cov report --release --html
           echo "COVERAGE_PERCENT=$(cargo +nightly llvm-cov report --release | tail -n1 | awk '{ print $13 }')" | tee --append $GITHUB_ENV
@@ -186,11 +186,11 @@ jobs:
       - *cache
       - name: Run clippy with specific features
         run: |
-          cargo clippy --no-default-features -- -Dwarnings
-          cargo clippy --no-default-features --features cli -- -Dwarnings
-          cargo clippy --no-default-features --features image -- -Dwarnings
-          cargo clippy --no-default-features --features listen -- -Dwarnings
-          cargo clippy --no-default-features --features frizbee -- -Dwarnings
+          cargo clippy --locked --no-default-features -- -Dwarnings
+          cargo clippy --locked --no-default-features --features cli -- -Dwarnings
+          cargo clippy --locked --no-default-features --features image -- -Dwarnings
+          cargo clippy --locked --no-default-features --features listen -- -Dwarnings
+          cargo clippy --locked --no-default-features --features frizbee -- -Dwarnings
 
 
   msrv:
@@ -198,11 +198,8 @@ jobs:
     steps:
       - *checkout
       - *toolchain
-      - uses: taiki-e/install-action@v2.87.1
-        with:
-          tool: cargo-msrv@0.19
       - name: MSRV Verify
-        run: cargo msrv verify
+        run: cargo +1.91.0 build --all-targets
 
   fuzz:
     permissions:
@@ -280,7 +277,7 @@ jobs:
         name: Fetch release tags
       - run: |
           latest_tag="$(git tag --list 'v*' --sort=-version:refname | head -n1)"
-          cargo public-api diff "${latest_tag}..HEAD" --deny removed --deny changed
+          cargo public-api diff "${latest_tag}..HEAD" --deny removed --deny changed --omit blanket-impls,auto-trait-impls,auto-derived-impls
         name: Run cargo-public-api
 
 


### PR DESCRIPTION
## Checklist

- [x] The title of my PR follows [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/)
- [ ] I have updated the documentation (`README.md`, comments, `src/manpage.rs` and/or `src/options.rs` if applicable) 
- [ ] I have added unit tests
- [ ] I have added [integration tests](https://github.com/skim-rs/skim/tree/master/tests)
- [ ] I have linked all related issues or PRs

## Description of the changes




<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Chores**
  - Automated validation now consistently uses the committed dependency lockfile.
  - Minimum-supported-Rust-version checks now build all targets with the specified toolchain.
  - Public API comparisons now exclude automatically generated and blanket implementations.
  - Documentation and shell-completion generation checks validate locked dependency resolution.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->